### PR TITLE
fix(package.json): fixed the error of npm i and deleted the useless p…

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
   },
   "dependencies": {
     "@opentiny/vue": "3.13.0",
-    "@opentiny/vue-icon": "^3.17.0",
-    "@opentiny/vue-theme": "^3.17.5",
     "@vitejs/plugin-vue": "4.0.0",
     "axios": "0.28.0",
     "d3": "6.6.2",
@@ -43,7 +41,7 @@
     "@rollup/plugin-babel": "6.0.4",
     "@rollup/plugin-commonjs": "25.0.7",
     "@rollup/plugin-node-resolve": "15.2.3",
-    "@rollup/plugin-strip": "2.0.0",
+    "@rollup/plugin-strip": "3.0.2",
     "@rollup/plugin-url": "8.0.1",
     "@types/node": "20.11.14",
     "@vitejs/plugin-vue": "4.0.0",
@@ -53,7 +51,7 @@
     "eslint-plugin-vue": "9.18.1",
     "less": "4.2.0",
     "postcss": "8.4.33",
-    "rollup": "4.9.6",
+    "rollup": "3.29.4",
     "rollup-plugin-copy": "3.5.0",
     "vite": "4.5.3",
     "vite-plugin-monaco-editor": "1.1.0"


### PR DESCRIPTION
…ackage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Updates**
	- Removed dependencies: `@opentiny/vue-icon` and `@opentiny/vue-theme`.
	- Upgraded `@rollup/plugin-strip` to version `3.0.2`.
	- Downgraded `rollup` to version `3.29.4`.

**Note**: These changes may impact functionality and require additional testing for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->