### PR TITLE
fix(TreeMapChart): add padding attribute

### DIFF
--- a/src/components/TreeMapChart/handleSeries.js
+++ b/src/components/TreeMapChart/handleSeries.js
@@ -18,6 +18,7 @@ export function handleSeries(baseOpt, iChartOpt) {
   const data = iChartOpt.data;
   const color = iChartOpt.color;
   const roam = iChartOpt.roam;
+  const padding = iChartOpt.padding;
   const optionLabel = iChartOpt.label || {};
   const label = Object.assign({
     fontFamily: 'HarmonyHeiTi',
@@ -36,6 +37,10 @@ export function handleSeries(baseOpt, iChartOpt) {
       breadcrumb: {
         show: false,
       },
+      top: padding[0],
+      right: padding[1],
+      bottom: padding[2],
+      left: padding[3],
       label,
       itemStyle: {
         borderRadius: 4,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `padding` parameter for enhanced customization of chart layouts, allowing users to specify spacing around the chart directly through options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->