### PR TITLE
fix(HeatMapChart): resolve the bug where the x-axis label is offset t…

### DIFF
--- a/src/components/HeatMapChart/handleOptipn.js
+++ b/src/components/HeatMapChart/handleOptipn.js
@@ -182,8 +182,6 @@ function handleRectangularXaxis(xAxis) {
 function handleCalendarXaxis(xAxis, data) {
   xAxis.data = data[0];
   xAxis.axisTick.show = false;
-  // 给文本设置左侧padding，使其不溢出
-  xAxis.axisLabel.padding = [0, 0, 0, (10 * data[0][0].length) / 2];
 }
 
 function handleHexagonXaxis(xAxis, data) {


### PR DESCRIPTION
…o the right and not centered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the display of axis labels in the Heat Map Chart by removing padding, which may improve label visibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->