### PR TITLE
fix(tooltip): modify the error that the extracssText are repeatedly a…

### DIFF
--- a/src/option/config/tooltip/index.js
+++ b/src/option/config/tooltip/index.js
@@ -32,8 +32,8 @@ function tooltip(iChartOption, chartName, callBack) {
   axisPointer(tooltip, chartName);
   callBack && callBack(tooltip)
   merge(tooltip, iChartOption.tooltip);
-  if (tooltip.extraCssText) {
-    tooltip.extraCssText = tooltip.extraCssText + extraCssText;
+  if (iChartOption.tooltip?.extraCssText) {
+    tooltip.extraCssText = iChartOption.tooltip.extraCssText + extraCssText;
   }
   return tooltip;
 }


### PR DESCRIPTION
…dded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the `extraCssText` property in tooltips to prevent unnecessary concatenation when not defined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->