### PR TITLE
fix(JadeJueChart): update barWidth and barGap

### DIFF
--- a/doc/api/JadeJueChart/position.md
+++ b/doc/api/JadeJueChart/position.md
@@ -12,4 +12,4 @@
 
 <p class='ev_expand_introduce'>默认值：<code>['20%','60%']</code>
 
-<p class='ev_expand_introduce'>说明：调整玉玦图的大小
+<p class='ev_expand_introduce'>说明：调整玉玦图的大小 ( 当第一项设置为<code>auto</code>时(即：<code>['auto','60%']</code>), 玉玦图会根据主题规范自动设置内圈大小 )

--- a/src/components/JadeJueChart/handleOption.js
+++ b/src/components/JadeJueChart/handleOption.js
@@ -13,11 +13,50 @@ import cloneDeep from '../../util/cloneDeep';
 import { getColor } from '../../util/color';
 import defendXSS from '../../util/defendXSS';
 
+// 主题中 线宽由线数量来决定
+function setThemeBarWidth(theme, data, position){
+  const isClound = theme.indexOf('clound') > -1;
+  let barWidth;
+  if(data.length >= 5){
+    barWidth = isClound ? 4: 8;
+  }else if(data.length ===4){
+    barWidth = isClound ? 6: 12;
+  }else if(data.length <= 3){
+    barWidth = isClound ? 8: 16;
+  }
+  return barWidth
+}
+
+// 主题中 线间距为文本的行高（当前规范字体12 行高为20）减去线宽 
+// 计算内圈的大小，用外圈尺寸 - (lineHeight*data.length)
+function setThemeRadius(iChartOption, baseOpt, chartInstance){
+  const lineHeight = 20;
+  const { _dom } = chartInstance;
+  const { data } = iChartOption;
+  const { width, height } = _dom.getBoundingClientRect();
+  const canvasRadius = width > height ? height / 2 : width / 2;
+  let outerRing = baseOpt.polar.radius[1];
+  let innerRing;
+  if(typeof outerRing === 'number'){
+    innerRing = outerRing - (lineHeight*data.length) 
+  }else if(outerRing.indexOf('%')>-1){
+    outerRing = Number(outerRing.slice(0,-1)) / 100;
+    innerRing = outerRing*canvasRadius - (lineHeight*data.length)
+  }
+  baseOpt.polar.radius[0] = innerRing;
+}
+
 // 配置玉玦图默认线宽为8
-export function setbarWidth(iChartOption, baseOpt) {
-  const { barWidth = 8 } = iChartOption;
+export function setbarWidth(iChartOption, baseOpt, chartInstance) {
+  const { barWidth = 8, theme, data, position } = iChartOption;
+  let themeBarWidth;
+  // 有配置主题时，根据规范设置线宽 与 线间距
+  if(theme){
+    themeBarWidth = setThemeBarWidth(theme, data, position)
+    if(!position?.radius || position?.radius?.[0] === 'auto')setThemeRadius(iChartOption, baseOpt, chartInstance)
+  }
   baseOpt.series.forEach(series => {
-    series.barWidth = barWidth;
+    series.barWidth = barWidth ? barWidth : themeBarWidth;
   });
 }
 

--- a/src/components/JadeJueChart/index.js
+++ b/src/components/JadeJueChart/index.js
@@ -43,7 +43,7 @@ class JadeJueChart {
     // 配置玉玦图的seriesData数据（value,name,color）
     setSeriesData(iChartOption, this.baseOption);
     // 设置默认线宽为(8=>16)
-    setbarWidth(iChartOption, this.baseOption);
+    setbarWidth(iChartOption, this.baseOption, chartInstance);
     // 配置玉玦图的起点角度及文本位置
     setStartAngle(iChartOption, this.baseOption);
     // 为第一种数据类型单独配置legend.data和对应颜色


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for `position.radius` in JadeJueChart to clarify automatic inner circle sizing when first radius item is set to `auto`

- **New Features**
	- Added dynamic theme-based calculations for bar width and inner ring radius
	- Enhanced chart configuration flexibility for automatic sizing and theme-based settings

- **Improvements**
	- Modified `setbarWidth` method to support more advanced theme and data-driven configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->