### PR TITLE
fix(JadeJueChart): fix the issue where angleAxis.axisTick.show fails

### DIFF
--- a/src/components/JadeJueChart/labelFormatter.js
+++ b/src/components/JadeJueChart/labelFormatter.js
@@ -157,7 +157,6 @@ const handleLabelFormatter = (iChartOption, baseOpt) => {
         return;
     }
     angleAxis.axisLabel.formatter = formatter;
-    angleAxis.axisTick.show = true; // 展示刻度线
 };
 
 export { handleLabelFormatter };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Refined chart visuals by updating the way axis tick markers are displayed, resulting in a cleaner and less cluttered appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->