### PR TITLE
fix(JadeJueChart):  fix default value of angleAxis.axisTick.show

### DIFF
--- a/src/components/JadeJueChart/labelFormatter.js
+++ b/src/components/JadeJueChart/labelFormatter.js
@@ -154,6 +154,7 @@ const handleLabelFormatter = (iChartOption, baseOpt) => {
     }
     if (type === 'process') {
         angleAxis.axisLabel.show = false;
+        angleAxis.axisTick.show = false;
         return;
     }
     angleAxis.axisLabel.formatter = formatter;

--- a/src/option/config/angleAxis/index.js
+++ b/src/option/config/angleAxis/index.js
@@ -17,6 +17,7 @@ function angleAxis(iChartOption, chartName) {
   switch (chartName) {
     case 'JadeJueChart':
       angleAxisOpt = base();
+      angleAxisOpt.axisTick.show = true;
       merge(angleAxisOpt, iChartOption.angleAxis);
       break;
     case 'PolarBarChart':


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the JadeJueChart to now display axis ticks, enhancing its visual clarity without affecting other chart types.
	- Enhanced control over axis tick visibility based on data type in the JadeJueChart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->