### PR TITLE
feat(token): change the font size of the coordinate axis name in the Cartesian coordinate system from 14 to 12

### DIFF
--- a/src/feature/token/factory/getModelToken.js
+++ b/src/feature/token/factory/getModelToken.js
@@ -134,7 +134,7 @@ function getModelToken(aliasToken) {
     // x轴名称颜色
     xAxisNameColor: colorTextSecondary,
     // x轴名称字号
-    xAxisNameFontSize: textFontSize,
+    xAxisNameFontSize: subtextFontSize,
     // x轴标签文本颜色
     xAxisLabelColor: colorTextTertiary,
     // x轴标签文本字号
@@ -164,7 +164,7 @@ function getModelToken(aliasToken) {
     // y轴名称颜色
     yAxisNameColor: colorTextSecondary,
     // y轴名称字号
-    yAxisNameFontSize: textFontSize,
+    yAxisNameFontSize: subtextFontSize,
     // y轴标签文本颜色
     yAxisLabelColor: colorTextTertiary,
     // y轴标签文本字号


### PR DESCRIPTION
change the font size of the coordinate axis name in the Cartesian coordinate system from 14 to 12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Refined the font sizing for chart axis labels to enhance visual consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->