### PR TITLE
feat(token): add cloud-dark theme token and fix the color of the hdesign-light

### DIFF
--- a/src/components/GaugeChart/handleSeries.js
+++ b/src/components/GaugeChart/handleSeries.js
@@ -129,7 +129,7 @@ function handleTheme(iChartOption) {
   const { orbitalColor } = iChartOption;
   seriesInit.axisLine.lineStyle.color = [[1, orbitalColor || chartToken.axisLineColor]];
   seriesInit.splitLine.lineStyle.color = chartToken.splitLineColor;
-  seriesInit.axisLabel.color = chartToken.descRichColor;
+  seriesInit.axisLabel.color = chartToken.axisLabel;
 }
 
 // 配置仪表盘中心文本

--- a/src/components/LineChart/handlePredict.js
+++ b/src/components/LineChart/handlePredict.js
@@ -24,7 +24,7 @@ function setDashedLineVisualMap(seriesIndex, lineColor, predictIndex) {
       {
         gte: 0,
         lte: predictIndex,
-        color: Theme.config.visualMapPiecesColor,
+        color: chartToken.colorNone,
       },
       {
         gt: predictIndex,
@@ -79,7 +79,7 @@ export function handlePredict(option, iChartOpt) {
   const { predict, tipHtml, lineStyle } = iChartOpt
   if (!predict) return
   // VisualMap只能处理线的颜色，不能处理面积的颜色
-  let dashColor = Theme.config.visualMapDashColor;
+  let dashColor = chartToken.maskColor;
   if (lineStyle && lineStyle.dashColor) {
     dashColor = lineStyle.dashColor;
   }

--- a/src/components/LineChart/handleSeries.js
+++ b/src/components/LineChart/handleSeries.js
@@ -116,7 +116,7 @@ function isTopOrBottom(markLine, seriesUnit, flag) {
     markLineData.lineStyle.color = markLineColor
   }
   if (markLinelLineStyle === false) {
-    markLineData.lineStyle.color = chartToken.color;
+    markLineData.lineStyle.color = chartToken.colorNone;
   }
   seriesUnit.markLine.data.push(markLineData);
 }

--- a/src/components/ProcessChart/BaseOption.js
+++ b/src/components/ProcessChart/BaseOption.js
@@ -45,7 +45,7 @@ function getDataNameSeries() {
     silent: true,
     label: {
       show: true,
-      color: chartToken.labelColor,
+      color: chartToken.nameColor,
       position: [0, -20],
       fontSize: chartToken.fontSize,
       formatter(params) {
@@ -129,7 +129,7 @@ function getDoubleBackgroundSeries(left = true) {
       rich: {
         name: {
           fontSize: chartToken.fontSize,
-          color: chartToken.disabledColor,
+          color: chartToken.nameColor,
           lineHeight: 14,
           padding: [0, 0, 20, 0],
         },

--- a/src/feature/card/index.js
+++ b/src/feature/card/index.js
@@ -44,7 +44,6 @@ class CardManager {
         cardContainer.style.setProperty('--selectBgAInactive', chartToken.selectBgAInactive);
         cardContainer.style.setProperty('--selectBgAInactive', chartToken.selectBgAInactive);
         cardContainer.style.setProperty('--selectTextDisabled', chartToken.selectTextDisabled);
-        cardContainer.style.setProperty('--borderColor', chartToken.borderColor);
         cardContainer.style.setProperty('--selectSplitLineColor', chartToken.selectSplitLineColor);
     }
     // 创建容器

--- a/src/feature/linter/lints/charts/Radar.js
+++ b/src/feature/linter/lints/charts/Radar.js
@@ -17,7 +17,7 @@ function getRadarRule() {
     const chartToken = Theme.getChartTokenByName(CHART_TYPE.RADAR)
     return {
         series: {
-            symbolSize: chartToken.symbolSize-2,
+            symbolSize: chartToken.symbolSize - 2,
             itemStyle: {
                 borderWidth: chartToken.itemBorderWidth,
                 borderColor: chartToken.itemBorderColor,

--- a/src/feature/linter/lints/modules/dataZoom.js
+++ b/src/feature/linter/lints/modules/dataZoom.js
@@ -26,10 +26,10 @@ function getDataZoomToken() {
         },
         dataBackground: {
             lineStyle: {
-                color: token.dataBackgroundLineColor,
+                color: token.dataZoomDataBackgroundLineColor,
             },
             areaStyle: {
-                color: token.dataBackgroundAreaColor,
+                color: token.dataZoomDataBackgroundAreaColor,
             },
         },
         selectedDataBackground: {

--- a/src/feature/token/color/cloud/board-dark.js
+++ b/src/feature/token/color/cloud/board-dark.js
@@ -1,0 +1,260 @@
+/**
+ * Copyright (c) 2024 - present OpenTiny HUICharts Authors.
+ * Copyright (c) 2024 - present Huawei Cloud Computing Technologies Co., Ltd.
+ *
+ * Use of this source code is governed by an MIT-style license.
+ *
+ * THE OPEN SOURCE SOFTWARE IN THIS PRODUCT IS DISTRIBUTED IN THE HOPE THAT IT WILL BE USEFUL,
+ * BUT WITHOUT ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS FOR
+ * A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
+ *
+ */
+
+// dark色板缺少kelly
+const red = {
+  colorRed10: '#FFF1ED',
+  colorRed20: '#FAD9D0',
+  colorRed30: '#F5C4B8',
+  colorRed40: '#F0B0A0',
+  colorRed50: '#E88F7D',
+  colorRed60: '#E16E5C',
+  colorRed70: '#D95A4C',
+  colorRed80: '#D94838',
+  colorRed90: '#B6332A',
+  colorRed100: '#931814',
+  colorRed110: '#700505',
+  colorRed120: '#4D0003',
+  colorRed130: '#330002',
+};
+
+const orange = {
+  colorOrange10: '#FFF8E8',
+  colorOrange20: '#FFEECC',
+  colorOrange30: '#FFE5B0',
+  colorOrange40: '#FFD78F',
+  colorOrange50: '#FFC269',
+  colorOrange60: '#FFAC3D',
+  colorOrange70: '#FF9824',
+  colorOrange80: '#FF8800',
+  colorOrange90: '#D67413',
+  colorOrange100: '#A6520A',
+  colorOrange110: '#703204',
+  colorOrange120: '#4D1F00',
+  colorOrange130: '#331400',
+};
+
+const yellow = {
+  colorYellow10: '#FFFCF0',
+  colorYellow20: '#FFF7D4',
+  colorYellow30: '#FFEFB5',
+  colorYellow40: '#FFE799',
+  colorYellow50: '#FFDC7D',
+  colorYellow60: '#FFCE5C',
+  colorYellow70: '#FFBB33',
+  colorYellow80: '#EBA92F',
+  colorYellow90: '#D69722',
+  colorYellow100: '#A67417',
+  colorYellow110: '#734D08',
+  colorYellow120: '#4D3200',
+  colorYellow130: '#332000',
+};
+
+const lemon = {
+  colorLemon10: '#FCFFEA',
+  colorLemon20: '#F7FCC7',
+  colorLemon30: '#F5FAAF',
+  colorLemon40: '#F3F77C',
+  colorLemon50: '#F5F558',
+  colorLemon60: '#F2EC30',
+  colorLemon70: '#E6DF25',
+  colorLemon80: '#D9CF1E',
+  colorLemon90: '#BDB115',
+  colorLemon100: '#998C12',
+  colorLemon110: '#766709',
+  colorLemon120: '#4D4000',
+  colorLemon130: '#003303',
+};
+
+const lime = {
+  colorLime10: '#FFFFEB',
+  colorLime20: '#F4F6BD',
+  colorLime30: '#E6ED93',
+  colorLime40: '#D8E36B',
+  colorLime50: '#C6DA46',
+  colorLime60: '#B7D134',
+  colorLime70: '#A4BF28',
+  colorLime80: '#93B020',
+  colorLime90: '#819E18',
+  colorLime100: '#718F10',
+  colorLime110: '#516E04',
+  colorLime120: '#364D00',
+  colorLime130: '#273800',
+};
+
+const green = {
+  colorGreen10: '#F3FFF0',
+  colorGreen20: '#D8EED1',
+  colorGreen30: '#BCDCB4',
+  colorGreen40: '#A2CB9A',
+  colorGreen50: '#8ABA82',
+  colorGreen60: '#75B06D',
+  colorGreen70: '#5BA854',
+  colorGreen80: '#39A632',
+  colorGreen90: '#2C9624',
+  colorGreen100: '#208718',
+  colorGreen110: '#166610',
+  colorGreen120: '#054D00',
+  colorGreen130: '#003303',
+};
+
+const mint = {
+  colorMint10: '#F0FFFA',
+  colorMint20: '#D2FAED',
+  colorMint30: '#BAF1E1',
+  colorMint40: '#88E3C9',
+  colorMint50: '#5BD4BA',
+  colorMint60: '#33C6AB',
+  colorMint70: '#0BB8A3',
+  colorMint80: '#0FA694',
+  colorMint90: '#159987',
+  colorMint100: '#0A8274',
+  colorMint110: '#02675B',
+  colorMint120: '#004D47',
+  colorMint130: '#00332F'
+};
+
+const sky = {
+  colorSky10: '#F2FCFF',
+  colorSky20: '#DCF5FD',
+  colorSky30: '#C0EEFD',
+  colorSky40: '#A6E5FC',
+  colorSky50: '#82D6FA',
+  colorSky60: '#64C8FA',
+  colorSky70: '#45B7F7',
+  colorSky80: '#2FA7EB',
+  colorSky90: '#3692CF',
+  colorSky100: '#3475AD',
+  colorSky110: '#285385',
+  colorSky120: '#1E3E63',
+  colorSky130: '#152A47',
+};
+
+const blue = {
+  colorBlue10: '#F2F9FF',
+  colorBlue20: '#DBEEFF',
+  colorBlue30: '#C0DEFD',
+  colorBlue40: '#A2CAFA',
+  colorBlue50: '#74ADF7',
+  colorBlue60: '#5291FF',
+  colorBlue70: '#317AF7',
+  colorBlue80: '#326DE3',
+  colorBlue90: '#2B60CC',
+  colorBlue100: '#264DAB',
+  colorBlue110: '#082677',
+  colorBlue120: '#00124D',
+  colorBlue130: '#003303',
+};
+
+const indigo = {
+  colorIndigo10: '#F5F2FF',
+  colorIndigo20: '#E6E0FF',
+  colorIndigo30: '#D3CBF4',
+  colorIndigo40: '#B9AFE9',
+  colorIndigo50: '#9E95DD',
+  colorIndigo60: '#847CD2',
+  colorIndigo70: '#716ACC',
+  colorIndigo80: '#5F58C7',
+  colorIndigo90: '#3F3BA8',
+  colorIndigo100: '#20208A',
+  colorIndigo110: '#0C0F6B',
+  colorIndigo120: '#00054D',
+  colorIndigo130: '#000333',
+};
+
+const purple = {
+  colorPurple10: '#F8F1FE',
+  colorPurple20: '#EAD7FA',
+  colorPurple30: '#DABCF5',
+  colorPurple40: '#CBA6ED',
+  colorPurple50: '#BB8BE8',
+  colorPurple60: '#A56EDB',
+  colorPurple70: '#9157C9',
+  colorPurple80: '#7A3DB8',
+  colorPurple90: '#6A29AB',
+  colorPurple100: '#571796',
+  colorPurple110: '#470F80',
+  colorPurple120: '#340463',
+  colorPurple130: '#1A0033',
+};
+
+const pink = {
+  colorPink10: '#FFF2FD',
+  colorPink20: '#F7D9F3',
+  colorPink30: '#FAC8F3',
+  colorPink40: '#F7ADEE',
+  colorPink50: '#F092E6',
+  colorPink60: '#E866DF',
+  colorPink70: '#E14ADB',
+  colorPink80: '#D92ED9',
+  colorPink90: '#B01BB6',
+  colorPink100: '#8A0D93',
+  colorPink110: '#650370',
+  colorPink120: '#42004D',
+  colorPink130: '#2C0033',
+};
+
+const rose = {
+  colorRose10: '#FEE5F2',
+  colorRose20: '#FCCFE6',
+  colorRose30: '#FCB8DA',
+  colorRose40: '#F99FCA',
+  colorRose50: '#F786B8',
+  colorRose60: '#F470AB',
+  colorRose70: '#ED448A',
+  colorRose80: '#E61866',
+  colorRose90: '#C40054',
+  colorRose100: '#811439',
+  colorRose110: '#540D24',
+  colorRose120: '#330614',
+  colorRose130: '#1F010A',
+};
+
+const gray = {
+  colorGray0: '#000000',
+  colorGray5: '#0D0D0D',
+  colorGray10: '#1A1A1A',
+  colorGray15: '#262626',
+  colorGray20: '#333333',
+  colorGray30: '#4D4D4D',
+  colorGray40: '#666666',
+  colorGray50: '#808080',
+  colorGray60: '#999999',
+  colorGray70: '#B3B3B3',
+  colorGray80: '#CCCCCC',
+  colorGray90: '#E6E6E6',
+  colorGray100: '#FFFFFF',
+};
+
+const transparent = {
+  colorTransparent: 'transparent',
+};
+
+const board = {
+  red,
+  sky,
+  lime,
+  rose,
+  mint,
+  blue,
+  pink,
+  gray,
+  lemon,
+  green,
+  orange,
+  yellow,
+  indigo,
+  purple,
+  transparent,
+};
+
+export default board;

--- a/src/feature/token/color/cloud/board.js
+++ b/src/feature/token/color/cloud/board.js
@@ -9,21 +9,7 @@
  * A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
  *
  */
-const rose = {
-  colorRose10: '#FFEBF3',
-  colorRose20: '#FFD6E8',
-  colorRose30: '#FAA0CB',
-  colorRose40: '#F56EAD',
-  colorRose50: '#F24998',
-  colorRose60: '#E61C81',
-  colorRose70: '#B50E65',
-  colorRose80: '#940A54',
-  colorRose90: '#70033F',
-  colorRose100: '#4D002B',
-  colorRose110: '#993D6E',
-  colorRose120: '#CC7AA6',
-  colorRose130: '#E6B8D2',
-};
+
 
 const red = {
   colorRed10: '#FFF1F0',
@@ -32,7 +18,7 @@ const red = {
   colorRed40: '#FA8682',
   colorRed50: '#F76360',
   colorRed60: '#F23030',
-  colorRed70: '#CC272A',
+  colorRed70: '#BF0A1C',
   colorRed80: '#A3171C',
   colorRed90: '#78080E',
   colorRed100: '#4D0005',
@@ -231,6 +217,22 @@ const pink = {
   colorPink110: '#993D99',
   colorPink120: '#C97ACC',
   colorPink130: '#E2B8E6',
+};
+
+const rose = {
+  colorRose10: '#FFEBF3',
+  colorRose20: '#FFD6E8',
+  colorRose30: '#FAA0CB',
+  colorRose40: '#F56EAD',
+  colorRose50: '#F24998',
+  colorRose60: '#E61C81',
+  colorRose70: '#B50E65',
+  colorRose80: '#940A54',
+  colorRose90: '#70033F',
+  colorRose100: '#4D002B',
+  colorRose110: '#993D6E',
+  colorRose120: '#CC7AA6',
+  colorRose130: '#E6B8D2',
 };
 
 const gray = {

--- a/src/feature/token/color/cloud/dark.js
+++ b/src/feature/token/color/cloud/dark.js
@@ -21,13 +21,13 @@ const gray = {
 // 图表的状态颜色
 const colorState = {
   // 紧急色
-  colorError: board.red.colorRed50,
-  colorAlert: board.orange.colorOrange50,
+  colorError: board.red.colorRed80,
+  colorAlert: board.orange.colorOrange80,
   colorWarning: board.yellow.colorYellow70,
   // 成功色
-  colorSuccess: board.green.colorGreen50,
+  colorSuccess: board.green.colorGreen70,
   // 提示色
-  colorInfo: board.blue.colorBlue40,
+  colorInfo: board.blue.colorBlue70,
   // 失效
   colorNone: board.gray.colorGray50,
 };

--- a/src/feature/token/color/cloud/dark.js
+++ b/src/feature/token/color/cloud/dark.js
@@ -10,7 +10,7 @@
  *
  */
 // 目前没有黑色主题，图表配色延用白色主题
-import board from './board';
+import board from './board-dark';
 import { getThemeColor, getColorGroup } from '../util';
 
 const gray = {
@@ -20,34 +20,50 @@ const gray = {
 
 // 图表的状态颜色
 const colorState = {
-	// 成功色
-  colorSuccess: board.kelly.colorKelly60,
   // 紧急色
-  colorError: board.red.colorRed60,
-  colorAlert: board.orange.colorOrange60,
-	// 失效
-  colorNone: board.gray.colorGray50,
-  colorWarning: board.yellow.colorYellow60,
+  colorError: board.red.colorRed50,
+  colorAlert: board.orange.colorOrange50,
+  colorWarning: board.yellow.colorYellow70,
+  // 成功色
+  colorSuccess: board.green.colorGreen50,
   // 提示色
-  colorInfo: board.blue.colorBlue60
-  
+  colorInfo: board.blue.colorBlue40,
+  // 失效
+  colorNone: board.gray.colorGray50,
 };
 
 // 图表配色对象
 const colorChart = {
-	colorChart1: board.blue.colorBlue60,
+  colorChart1: board.blue.colorBlue70,
   colorChart2: board.mint.colorMint70,
-  colorChart3: board.indigo.colorIndigo50,
-  colorChart4: board.kelly.colorKelly60,
-	colorChart5: board.yellow.colorYellow60,
-  colorChart6: board.sky.colorSky60,
-  colorChart7: board.purple.colorPurple50,
-  colorChart8: board.rose.colorRose50, // (原色 '#EB4696')
+  colorChart3: board.indigo.colorIndigo70,
+  colorChart4: board.green.colorGreen70,
+  colorChart5: board.yellow.colorYellow70,
+  colorChart6: board.sky.colorSky70,
+  colorChart7: board.purple.colorPurple70,
+  colorChart8: board.rose.colorRose70,
+  colorChart9: board.blue.colorBlue50,
+  colorChart10: board.mint.colorMint90,
+  colorChart11: board.indigo.colorIndigo40,
+  colorChart12: board.green.colorGreen90,
+  colorChart13: board.yellow.colorYellow50,
+  colorChart14: board.sky.colorSky90,
+  colorChart15: board.purple.colorPurple50,
+  colorChart16: board.rose.colorRose90,
+  colorChart17: board.mint.colorMint50,
+  colorChart18: board.blue.colorBlue90,
+  colorChart19: board.green.colorGreen50,
+  colorChart20: board.indigo.colorIndigo90,
+  colorChart21: board.sky.colorSky50,
+  colorChart22: board.yellow.colorYellow90,
+  colorChart23: board.rose.colorRose40,
+  colorChart24: board.purple.colorPurple90,
+  colorChart25: board.lime.colorLime90
 };
 
 // 图表内置的颜色组
 const colorGroup = getColorGroup(colorChart);
 
-const dark = getThemeColor(gray, colorState, colorGroup,board);
+const dark = getThemeColor(gray, colorState, colorGroup, board);
 
 export default dark;

--- a/src/feature/token/color/cloud/light.js
+++ b/src/feature/token/color/cloud/light.js
@@ -31,7 +31,7 @@ const colorState = {
   colorNone: board.gray.colorGray50,
 };
 
-// 图表配色对象
+// 图表配色对象 
 const colorChart = {
   colorChart1: board.blue.colorBlue60,
   colorChart2: board.mint.colorMint70,
@@ -40,12 +40,29 @@ const colorChart = {
   colorChart5: board.yellow.colorYellow60,
   colorChart6: board.sky.colorSky60,
   colorChart7: board.purple.colorPurple50,
-  colorChart8: board.rose.colorRose50, // (原色 '#EB4696')
+  colorChart8: board.rose.colorRose60,
+  colorChart9: board.blue.colorBlue40,
+  colorChart10: board.mint.colorMint80,
+  colorChart11: board.indigo.colorIndigo30,
+  colorChart12: board.kelly.colorKelly80,
+  colorChart13: board.yellow.colorYellow40,
+  colorChart14: board.sky.colorSky80,
+  colorChart15: board.purple.colorPurple40,
+  colorChart16: board.rose.colorRose70,
+  colorChart17: board.mint.colorMint50,
+  colorChart18: board.blue.colorBlue80,
+  colorChart19: board.kelly.colorKelly40,
+  colorChart20: board.indigo.colorIndigo60,
+  colorChart21: board.sky.colorSky40,
+  colorChart22: board.yellow.colorYellow80,
+  colorChart23: board.rose.colorRose30,
+  colorChart24: board.purple.colorPurple70,
+  colorChart25: board.lime.colorLime80
 };
 
 // 图表内置的颜色组
 const colorGroup = getColorGroup(colorChart);
 
-const light = getThemeColor(gray, colorState, colorGroup,board);
+const light = getThemeColor(gray, colorState, colorGroup, board);
 
 export default light;

--- a/src/feature/token/color/hdesign/dark.js
+++ b/src/feature/token/color/hdesign/dark.js
@@ -21,8 +21,8 @@ const colorState = {
   // 错误色
   colorError: board.red.colorRed40,
   colorAlert: board.orange.colorOrange50,
-	colorWarning: board.yellow.colorYellow40,
-	// 成功色
+  colorWarning: board.yellow.colorYellow40,
+  // 成功色
   colorSuccess: board.mint.colorMint60,
   // 信息色
   colorInfo: board.blue.colorBlue50,
@@ -35,19 +35,33 @@ const colorChart = {
   colorChart1: board.blue.colorBlue50,
   colorChart2: board.green.colorGreen50,
   colorChart3: board.indigo.colorIndigo50,
-  colorChart4:board.orange.colorOrange50,
-  colorChart5: board.cyan.colorCyan50,
-  colorChart6: board.pink.colorPink50,
-  colorChart7:  board.mint.colorMint50,
-  colorChart8: board.yellow.colorYellow50,
-  colorChart9:  board.purple.colorPurple50,
-  colorChart10: board.rose.colorRose50,
-  colorChart11:board.brand.colorBrand50
+  colorChart4: board.cyan.colorCyan50,
+  colorChart5: board.orange.colorOrange40,
+  colorChart6: board.brand.colorBrand30,
+  colorChart7: board.purple.colorPurple60,
+  colorChart8: board.rose.colorRose60,
+  colorChart9: board.indigo.colorIndigo60,
+  colorChart10: board.yellow.colorYellow60,
+  colorChart11: board.brand.colorBrand60,
+  colorChart12: board.green.colorGreen60,
+  colorChart13: board.purple.colorPurple70,
+  colorChart14: board.cyan.colorCyan60,
+  colorChart15: board.orange.colorOrange70,
+  colorChart16: board.rose.colorRose60,
+  colorChart17: board.cyan.colorCyan70,
+  colorChart18: board.blue.colorBlue60,
+  colorChart19: board.green.colorGreen70,
+  colorChart20: board.indigo.colorIndigo70,
+  colorChart21: board.rose.colorRose70,
+  colorChart22: board.cyan.colorCyan30,
+  colorChart23: board.yellow.colorYellow70,
+  colorChart24: board.purple.colorPurple50,
+  colorChart25: board.mint.colorMint70
 };
 
 // 图表内置的颜色组
 const colorGroup = getColorGroup(colorChart);
 
-const dark = getThemeColor(gray, colorState, colorGroup,board);
+const dark = getThemeColor(gray, colorState, colorGroup, board);
 
 export default dark;

--- a/src/feature/token/color/hdesign/light.js
+++ b/src/feature/token/color/hdesign/light.js
@@ -33,16 +33,30 @@ const colorState = {
 // 图表的配色对象
 const colorChart = {
   colorChart1: board.blue.colorBlue50,
-  colorChart2: board.green.colorGreen40,
+  colorChart2: board.green.colorGreen50,
   colorChart3: board.indigo.colorIndigo50,
-  colorChart4:board.orange.colorOrange40,
-  colorChart5: board.cyan.colorCyan50,
-  colorChart6: board.pink.colorPink40,
-  colorChart7:  board.mint.colorMint50,
-  colorChart8: board.yellow.colorYellow40,
-  colorChart9:  board.purple.colorPurple50,
-  colorChart10: board.rose.colorRose40,
-  colorChart11:board.brand.colorBrand50
+  colorChart4: board.cyan.colorCyan50,
+  colorChart5: board.orange.colorOrange40,
+  colorChart6: board.brand.colorBrand30,
+  colorChart7: board.purple.colorPurple40,
+  colorChart8: board.rose.colorRose40,
+  colorChart9: board.indigo.colorIndigo20,
+  colorChart10: board.yellow.colorYellow60,
+  colorChart11: board.brand.colorBrand10,
+  colorChart12: board.green.colorGreen60,
+  colorChart13: board.purple.colorPurple20,
+  colorChart14: board.cyan.colorCyan60,
+  colorChart15: board.orange.colorOrange20,
+  colorChart16: board.rose.colorRose60,
+  colorChart17: board.cyan.colorCyan20,
+  colorChart18: board.blue.colorBlue60,
+  colorChart19: board.green.colorGreen20,
+  colorChart20: board.indigo.colorIndigo70,
+  colorChart21: board.rose.colorRose10,
+  colorChart22: board.cyan.colorCyan70,
+  colorChart23: board.yellow.colorYellow20,
+  colorChart24: board.purple.colorPurple70,
+  colorChart25: board.mint.colorMint20
 };
 
 // 图表内置的颜色组

--- a/src/feature/token/factory/chartsToken/AreaChart.js
+++ b/src/feature/token/factory/chartsToken/AreaChart.js
@@ -10,9 +10,9 @@
  *
  */
 function AreaChart(aliasToken) {
-  const { colorBgTransparent } = aliasToken;
+  const { colorNone } = aliasToken;
   return {
-    colorAreaTP: colorBgTransparent,
+    colorAreaTP: colorNone,
 
   };
 };

--- a/src/feature/token/factory/chartsToken/AssembleBubbleChart.js
+++ b/src/feature/token/factory/chartsToken/AssembleBubbleChart.js
@@ -9,15 +9,13 @@
  * A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
  *
  */
-function AssembleBubbleChart(aliasToken){
-  const { colorLabel, colorLabelDisabled, colorBorderDisabled, colorInactive } = aliasToken;
-  //    此图为自定义echarts不知道怎么排布数据结构，todo
-  
+function AssembleBubbleChart(aliasToken) {
+  const { colorLabel, colorLabelDisabled, colorIconInactive } = aliasToken;
+
   return {
     labelColor: colorLabel,
     disabledLabelColor: colorLabelDisabled,
-    disabledBorderColor: colorBorderDisabled,
-    disabledItemColor: colorInactive,
+    disabledItemColor: colorIconInactive,
   };
 
 };

--- a/src/feature/token/factory/chartsToken/BarChart.js
+++ b/src/feature/token/factory/chartsToken/BarChart.js
@@ -9,15 +9,15 @@
  * A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
  *
  */
-function BarChart (aliasToken) {
-  const { borderWidth, barWidth, colorLabel, labelFontSize, colorBorderTransparent, borderRadius, colorBgTransparent } =
+function BarChart(aliasToken) {
+  const { borderWidth, barWidth, colorLabel, labelFontSize, borderRadius, colorNone } =
     aliasToken;
 
   return {
     borderWidth,
-    borderColor:colorBorderTransparent,
+    borderColor: colorNone,
     borderRadius,
-    color: colorBgTransparent,
+    color: colorNone,
     labelColor: colorLabel,
     fontSize: labelFontSize,
     barWidth,

--- a/src/feature/token/factory/chartsToken/BoxplotChart.js
+++ b/src/feature/token/factory/chartsToken/BoxplotChart.js
@@ -10,16 +10,16 @@
  *
  */
 function BoxplotChart(aliasToken) {
-  const { lineWidth, symbolSize, symbolBorderWidthNone, colorBorderTransparent, symbolBorderWidth,colorFillSecondary } = aliasToken;
+  const { lineWidth, symbolSize, symbolBorderWidthNone, colorNone, symbolBorderWidth, symbolFillHover } = aliasToken;
 
   return {
     boxplotItemStyleBorderWidth: lineWidth,
     boxplotEmphasisItemStyleBorderWidth: lineWidth,
     scatterSymbolSize: symbolSize,
     scatterItemBorderWidth: symbolBorderWidthNone,
-    scatterItemBorderColor: colorBorderTransparent,
+    scatterItemBorderColor: colorNone,
     scatterEmphasisItemBorderWidth: symbolBorderWidth,
-    scatterEmphasisItemColor: colorFillSecondary,
+    scatterEmphasisItemColor: symbolFillHover,
   };
 
 };

--- a/src/feature/token/factory/chartsToken/CandlestickChart.js
+++ b/src/feature/token/factory/chartsToken/CandlestickChart.js
@@ -9,11 +9,11 @@
  * A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
  *
  */
-function CandlestickChart (aliasToken) {
-  const { colorTextSecondary } = aliasToken;
+function CandlestickChart(aliasToken) {
+  const { colorAxisLabel } = aliasToken;
 
   return {
-    axisPointerLabelColor: colorTextSecondary,
+    axisPointerLabelColor: colorAxisLabel,
   };
 };
 

--- a/src/feature/token/factory/chartsToken/ChartCard.js
+++ b/src/feature/token/factory/chartsToken/ChartCard.js
@@ -10,24 +10,23 @@
  *
  */
 function ChartCard(aliasToken) {
-    const { colorTextPrimary, colorFill,colorTextSecondary,colorBorderInverse,colorBgPrimary,colorTextDisabled,colorBgTertiary} = aliasToken;
+    const { colorTitle, colorSeparatorLine, colorBgContainerHover, colorSubTitle, colorBgContainer, colorLabelDisabled } = aliasToken;
 
     return {
         // 卡片背景
-        cardBg: colorBgPrimary,
+        cardBg: colorBgContainer,
         // 标题的颜色
-        titleColor: colorTextPrimary,
+        titleColor: colorTitle,
         // 文本的颜色
-        labelColor: colorTextSecondary,
+        labelColor: colorSubTitle,
         // 选中背景色
-        selectBgActive:colorBgPrimary,
+        selectBgActive: colorBgContainer,
         // 未选中背景色
-        selectBgAInactive:colorBgTertiary,
+        selectBgAInactive: colorBgContainerHover,
         // 未选中文本色
-        selectTextDisabled:colorTextDisabled,
-        borderColor:colorBorderInverse,
+        selectTextDisabled: colorLabelDisabled,
         // 分隔线
-        selectSplitLineColor:colorFill
+        selectSplitLineColor: colorSeparatorLine
     };
 };
 

--- a/src/feature/token/factory/chartsToken/CircleProcessChart.js
+++ b/src/feature/token/factory/chartsToken/CircleProcessChart.js
@@ -10,10 +10,10 @@
  *
  */
 function CircleProcessChart (aliasToken){
-  const { colorBgEmpty } = aliasToken;
+  const { colorPlaceholder } = aliasToken;
   
   return {
-    background: colorBgEmpty,
+    background: colorPlaceholder,
   };
 };
 

--- a/src/feature/token/factory/chartsToken/FunnelChart.js
+++ b/src/feature/token/factory/chartsToken/FunnelChart.js
@@ -10,7 +10,7 @@
  *
  */
 function FunnelChart(aliasToken) {
-  const { colorLabel, borderWidthNone, colorBorder } = aliasToken;
+  const { colorLabel, borderWidthNone, colorNone } = aliasToken;
 
   return {
     // 标签文本颜色
@@ -18,7 +18,7 @@ function FunnelChart(aliasToken) {
     // 图形描边宽度
     borderWidth: borderWidthNone,
     // 图形描边颜色
-    borderColor: colorBorder,
+    borderColor: colorNone,
   };
 
 };

--- a/src/feature/token/factory/chartsToken/GaugeChart.js
+++ b/src/feature/token/factory/chartsToken/GaugeChart.js
@@ -9,16 +9,16 @@
  * A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
  *
  */
-function GaugeChart (aliasToken){
-  const { colorBgEmpty, colorAxisTickLine, colorTextTertiary, colorTextPrimary, colorTextSecondary} = aliasToken;
-  
+function GaugeChart(aliasToken) {
+  const { colorPlaceholder, colorAxisTickLine, colorTitle, colorSubTitle, colorAxisLabel } = aliasToken;
+
   return {
     // 用于轨道，特殊使用空数据颜色
-    axisLineColor: colorBgEmpty,
+    axisLineColor: colorPlaceholder,
     splitLineColor: colorAxisTickLine,
-    axisLabelColor: colorTextTertiary,
-    detailRichColor: colorTextPrimary,
-    descRichColor: colorTextSecondary
+    detailRichColor: colorTitle,
+    descRichColor: colorSubTitle,
+    axisLabel: colorAxisLabel
   };
 
 };

--- a/src/feature/token/factory/chartsToken/HeatMapChart.js
+++ b/src/feature/token/factory/chartsToken/HeatMapChart.js
@@ -10,11 +10,11 @@
  *
  */
 function HeatMapChart(aliasToken) {
-  const { colorLabel, colorBorder } = aliasToken;
+  const { colorLabel, colorMask } = aliasToken;
 
   return {
     labelColor: colorLabel,
-    hexagonStrokeColor: colorBorder,
+    hexagonStrokeColor: colorMask,
   };
 };
 

--- a/src/feature/token/factory/chartsToken/HillChart.js
+++ b/src/feature/token/factory/chartsToken/HillChart.js
@@ -9,12 +9,12 @@
  * A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
  *
  */
-function HillChart (aliasToken) {
-  const { colorLabel, colorBorder } = aliasToken;
-  
+function HillChart(aliasToken) {
+  const { colorLabel, colorMask } = aliasToken;
+
   return {
     labelColor: colorLabel,
-    emphasisItemBorderColor: colorBorder,
+    emphasisItemBorderColor: colorMask,
   };
 };
 

--- a/src/feature/token/factory/chartsToken/JadeJueChart.js
+++ b/src/feature/token/factory/chartsToken/JadeJueChart.js
@@ -10,12 +10,12 @@
  *
  */
 function JadeJueChart(aliasToken) {
-  const { colorBorder, colorBgEmpty, colorLabel, colorTextSecondary, paddingLG } = aliasToken;
+  const { colorPlaceholder, colorLabel, colorTextName, paddingLG, colorMask } = aliasToken;
 
   return {
-    itemBorderColor: colorBorder,
-    itemColor: colorBgEmpty,
-    labelValueColor: colorTextSecondary,
+    itemBorderColor: colorMask,
+    itemColor: colorPlaceholder,
+    labelValueColor: colorTextName,
     labelRatioColor: colorLabel,
     labelPadding: paddingLG
   };

--- a/src/feature/token/factory/chartsToken/JadeJueChart.js
+++ b/src/feature/token/factory/chartsToken/JadeJueChart.js
@@ -10,14 +10,16 @@
  *
  */
 function JadeJueChart(aliasToken) {
-  const { colorPlaceholder, colorLabel, colorTextName, paddingLG, colorMask } = aliasToken;
+  const { colorPlaceholder, colorLabel, colorTextName, padding, borderWidthLG, borderRadius, colorMask } = aliasToken;
 
   return {
     itemBorderColor: colorMask,
     itemColor: colorPlaceholder,
     labelValueColor: colorTextName,
     labelRatioColor: colorLabel,
-    labelPadding: paddingLG
+    labelPadding: padding,
+    itemBorderWidth: borderWidthLG,
+    itemBorderRadius: borderRadius,
   };
 
 };

--- a/src/feature/token/factory/chartsToken/LineChart.js
+++ b/src/feature/token/factory/chartsToken/LineChart.js
@@ -10,7 +10,7 @@
  *
  */
 function LineChart(aliasToken) {
-  const { colorBorder, borderWidthLG, borderWidthNone, symbolSize, symbolSizeSM, lineWidth, colorLineTransparent } =
+  const { borderWidthLG, borderWidthNone, symbolSize, symbolSizeSM, lineWidth, colorNone, colorMask } =
     aliasToken;
 
   return {
@@ -19,8 +19,10 @@ function LineChart(aliasToken) {
     lineWidth,
     borderZero: borderWidthNone,
     border: borderWidthLG,
-    borderColor: colorBorder,
-    color: colorLineTransparent,
+    borderColor: colorMask,
+    color: colorNone,
+    colorNone,
+    maskColor: colorMask
   };
 };
 

--- a/src/feature/token/factory/chartsToken/LiquidfillChart.js
+++ b/src/feature/token/factory/chartsToken/LiquidfillChart.js
@@ -10,11 +10,11 @@
  *
  */
 function LiquidfillChart(aliasToken) {
-  const { colorLabel, colorBgPrimary } = aliasToken;
+  const { colorLabel, colorBgContainer } = aliasToken;
 
   return {
     labelColor: colorLabel,
-    backgroundColor: colorBgPrimary,
+    backgroundColor: colorBgContainer,
   };
 
 };

--- a/src/feature/token/factory/chartsToken/PieChart.js
+++ b/src/feature/token/factory/chartsToken/PieChart.js
@@ -11,32 +11,32 @@
  */
 function PieChart(aliasToken) {
   const {
-    colorBorder,
+    colorMask,
     borderWidthLG,
     borderWidthNone,
-    colorLabel,
     labelFontSize,
     labelLineLength,
     colorLabelLine,
     borderRadiusNone,
-    colorBgEmpty,
+    colorPlaceholder,
+    colorLabelSecondary
   } = aliasToken;
 
   return {
     // 图形描边宽度
     borderWidth: borderWidthLG,
     // 图形描边颜色
-    borderColor: colorBorder,
+    borderColor: colorMask,
     // 图形内外圆角半径
     borderRadius: borderRadiusNone,
     // 数据和为0时图形描边宽度
     borderWidthShowZero: borderWidthNone,
     // 数据和为0时背景图形颜色
-    colorShowZero: colorBgEmpty,
+    colorShowZero: colorPlaceholder,
     // 标签文本字体大小
     labelFontSize,
     // 标签文本颜色
-    labelColor: colorLabel,
+    labelColor: colorLabelSecondary,
     // 标签引导线长度
     labelLineLength,
     // 标签引导线颜色

--- a/src/feature/token/factory/chartsToken/PolarBarChart.js
+++ b/src/feature/token/factory/chartsToken/PolarBarChart.js
@@ -10,12 +10,12 @@
  *
  */
 function PolarBarChart(aliasToken) {
-  const { colorTextSecondary } = aliasToken;
+  const { colorTextName } = aliasToken;
 
   // 坐标轴label
   return {
     // 坐标轴颜色
-    labelColor: colorTextSecondary,
+    labelColor: colorTextName,
   };
 };
 

--- a/src/feature/token/factory/chartsToken/ProcessChart.js
+++ b/src/feature/token/factory/chartsToken/ProcessChart.js
@@ -10,15 +10,15 @@
  *
  */
 function ProcessChart(aliasToken) {
-  const { colorAxisLine, colorLabel, colorTextDisabled, colorBgEmpty, borderWidth, colorBorderTransparent, borderRadius, textFontSize, labelFontSize } = aliasToken;
+  const { colorAxisLine, colorLabel, colorPlaceholder, borderWidth, colorNone, borderRadius, textFontSize, labelFontSize, colorLabelSecondary } = aliasToken;
 
   return {
+    nameColor: colorLabelSecondary,
     labelColor: colorLabel,
-    disabledColor: colorTextDisabled,
     axisLineColor: colorAxisLine,
-    itemBgEmpty: colorBgEmpty,
+    itemBgEmpty: colorPlaceholder,
     borderWidth,
-    borderColor: colorBorderTransparent,
+    borderColor: colorNone,
     borderRadius,
     fontSize: textFontSize,
     labelFontSize

--- a/src/feature/token/factory/chartsToken/RadarChart.js
+++ b/src/feature/token/factory/chartsToken/RadarChart.js
@@ -9,28 +9,28 @@
  * A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
  *
  */
-export default function  RadarChart (aliasToken) {
+export default function RadarChart(aliasToken) {
   const {
     symbolSize,
     lineWidth,
     lineWidthNone,
-    colorBgTransparent,
+    colorNone,
     symbolBorderWidth,
     symbolBorderWidthNone,
-    colorFillSecondary,
-    colorBorderTransparent
+    colorMask,
+    symbolFillHover
   } = aliasToken;
 
-  return  {
-    itemBorderWidth:symbolBorderWidthNone,
-    emphasisItemBorderWidth:symbolBorderWidth,
-    areaColor:colorBgTransparent,
+  return {
+    itemBorderWidth: symbolBorderWidthNone,
+    emphasisItemBorderWidth: symbolBorderWidth,
+    areaColor: colorNone,
     symbolSize,
     lineWidth,
-    thresholdLineWidth:lineWidthNone,
-    itemBorderColor:colorBorderTransparent,
-    emphasisItemColor: colorFillSecondary,
-    gradientItemBorderColor:colorFillSecondary
+    thresholdLineWidth: lineWidthNone,
+    itemBorderColor: colorNone,
+    emphasisItemColor: symbolFillHover,
+    gradientItemBorderColor: colorMask
   };
 };
 

--- a/src/feature/token/factory/chartsToken/RegionChart.js
+++ b/src/feature/token/factory/chartsToken/RegionChart.js
@@ -10,10 +10,10 @@
  *
  */
 function RegionChart(aliasToken) {
-  const { colorTextPrimary } = aliasToken;
+  const { colorLabel } = aliasToken;
 
   return {
-    visualMapTextColor: colorTextPrimary,
+    visualMapTextColor: colorLabel,
   };
 };
 

--- a/src/feature/token/factory/chartsToken/SankeyChart.js
+++ b/src/feature/token/factory/chartsToken/SankeyChart.js
@@ -10,11 +10,11 @@
  *
  */
 function SankeyChart(aliasToken) {
-  const { colorLabel, colorTextSecondary } = aliasToken;
+  const { colorLabel, colorTextName } = aliasToken;
 
   return {
     labelValueColor: colorLabel,
-    labelNameColor: colorTextSecondary
+    labelNameColor: colorTextName
   };
 
 };

--- a/src/feature/token/factory/chartsToken/ScatterChart.js
+++ b/src/feature/token/factory/chartsToken/ScatterChart.js
@@ -10,11 +10,11 @@
  *
  */
 function ScatterChart(aliasToken) {
-  const { colorBgPrimary } = aliasToken;
+  const { symbolFillHover } = aliasToken;
 
   return {
     // 散点聚焦时圆圈颜色
-    color: colorBgPrimary,
+    color: symbolFillHover,
   };
 };
 

--- a/src/feature/token/factory/chartsToken/SunburstChart.js
+++ b/src/feature/token/factory/chartsToken/SunburstChart.js
@@ -10,10 +10,10 @@
  *
  */
 function SunburstChart(aliasToken) {
-  const { colorBorder, colorLabel } = aliasToken;
+  const { colorMask, colorLabel } = aliasToken;
 
   return {
-    itemBorderColor: colorBorder,
+    itemBorderColor: colorMask,
     labelColor: colorLabel,
   };
 

--- a/src/feature/token/factory/chartsToken/TimelineChart.js
+++ b/src/feature/token/factory/chartsToken/TimelineChart.js
@@ -10,11 +10,10 @@
  *
  */
 function TimelineChart(aliasToken) {
-  const { colorBgPrimary, colorBgEmpty } = aliasToken;
+  const { colorPlaceholder } = aliasToken;
 
   return {
-    backgroundColor: colorBgPrimary,
-    roundRectBg: colorBgEmpty
+    roundRectBg: colorPlaceholder
   };
 
 };

--- a/src/feature/token/factory/chartsToken/WaveChart.js
+++ b/src/feature/token/factory/chartsToken/WaveChart.js
@@ -10,12 +10,12 @@
  *
  */
 function WaveChart(aliasToken) {
-  const { colorAxisLine, colorTextSecondary, colorAxisSplitLine } = aliasToken;
+  const { colorAxisLine, colorTextName, colorAxisLabel, colorAxisSplitLine } = aliasToken;
 
   return {
     axisLineColor: colorAxisLine,
-    axisLabelColor: colorTextSecondary,
-    axisNameColor: colorTextSecondary,
+    axisLabelColor: colorAxisLabel,
+    axisNameColor: colorTextName,
     splitLineColor: colorAxisSplitLine,
   };
 

--- a/src/feature/token/factory/chartsToken/WordCloudChart.js
+++ b/src/feature/token/factory/chartsToken/WordCloudChart.js
@@ -10,10 +10,10 @@
  *
  */
 function WordCloudChart(aliasToken) {
-  const { colorShadow } = aliasToken;
+  const { colorShadowContainer } = aliasToken;
 
   return {
-    emphasisTextShadowColor: colorShadow,
+    emphasisTextShadowColor: colorShadowContainer,
   };
 
 };

--- a/src/feature/token/factory/getGlobalToken.js
+++ b/src/feature/token/factory/getGlobalToken.js
@@ -20,5 +20,6 @@ export default function getGlobalToken(themeName) {
   return {
     ...globalToken,
     ...color[themeName].grayScale,
+    colorBoard: color[themeName].colorBoard,
   };
 }

--- a/src/feature/token/factory/getModelToken.js
+++ b/src/feature/token/factory/getModelToken.js
@@ -16,22 +16,18 @@
  */
 function getModelToken(aliasToken) {
   const {
-    colorTextPrimary,
-    colorDash,
-    colorBgSecondary,
-    colorTextTransparent,
-    colorIconPrimary,
-    colorTextSecondary,
+    colorLabel,
+    colorBgContainerSecondary,
+    colorIcon,
     colorAxisLine,
-    colorInactive,
-    colorIconDisabled,
+    colorIconInactive,
     colorAxisTickLine,
     colorAxisSplitLine,
     colorAxisPointerLine,
-    colorAxisPointerShadow,
-    colorShadow,
-    shadowOffsetY,
-    shadowBlur,
+    colorShadowHover,
+    colorShadowContainer,
+    shadowOffsetYContainer,
+    shadowBlurContainer,
     titleSpace,
     titleFontSize,
     subtitleFontSize,
@@ -52,27 +48,32 @@ function getModelToken(aliasToken) {
     legendItemSize,
     legendCircleItemSize,
     containerGap,
-    markLineWidth,
-    markLineEmphasisWidth,
-    colorBorder,
+    lineWidthSecondary,
     borderWidthNone,
     containerBoderRadius,
     paddingNone,
     paddingLG,
-    colorBgQuaternary,
-    colorShadowSecondary,
-    colorBorderSecondary,
-    colorAxisLineSecondary,
-    colorBgTertiary,
-    colorFill,
+    colorZoomHandle,
+    colorShadowHandle,
+    colorZoomHandleBorder,
+    colorAxisSplitLineSecondary,
+    colorZoomDataAreaFill,
     axisLineWidthSecondary,
     labelFontSize,
-    colorTextTertiary,
-    borderRadius,
-    paddingSM,
-    borderWidthLG,
-    colorBorderTransparent,
-    colorShadowTertiary
+    colorAxisLabel,
+    colorNone,
+    colorTextName,
+    colorTitle,
+    colorZoomBg,
+    colorSubTitle,
+    colorZoomDataAreaBorder,
+    colorZoomBorder,
+    colorZoomFill,
+    colorZoomSelectDataAreaFill,
+    colorZoomSelectDataAreaBorder,
+    shadowOffsetYHandle,
+    shadowBlurHandle,
+    zoomDataAreaBorderWidth
   } = aliasToken;
 
   return {
@@ -80,9 +81,9 @@ function getModelToken(aliasToken) {
     // 主副标题之前的间距
     titleItemGap: titleSpace,
     // 标题文本颜色
-    titleTextColor: colorTextPrimary,
+    titleTextColor: colorTitle,
     // 标题副文本颜色
-    titleSubTextColor: colorTextSecondary,
+    titleSubTextColor: colorSubTitle,
     // 标题文本字号
     titleTextFontSize: titleFontSize,
     // 标题副文本字号
@@ -90,9 +91,9 @@ function getModelToken(aliasToken) {
 
     /** -----图例------ */
     // 图例文本颜色
-    legendTextColor: colorTextSecondary,
+    legendTextColor: colorTextName,
     // 图例富文本颜色
-    legendTextRichColor: colorTextSecondary,
+    legendTextRichColor: colorTextName,
     // 图例文本字号
     legendTextFontSize: subtextFontSize,
     // 图例富文本颜色
@@ -110,15 +111,15 @@ function getModelToken(aliasToken) {
     // 方形图例时每项的高度
     legendReactItemHeight: legendItemSize,
     // 图例翻页文本颜色
-    legendPageTextColor: colorTextPrimary,
+    legendPageTextColor: colorLabel,
     // 图例翻页图标激活颜色
-    legendPageIconColor: colorIconPrimary,
+    legendPageIconColor: colorIcon,
     // 图例翻页图标失效颜色
-    legendPageIconInactiveColor: colorIconDisabled,
+    legendPageIconInactiveColor: colorIconInactive,
     // 图例失效颜色
-    legendInactiveColor: colorInactive,
+    legendInactiveColor: colorIconInactive,
     // 图例失效边框颜色
-    legendInactiveBorderColor: colorBorder,
+    legendInactiveBorderColor: colorNone,
     // 图例边框宽度
     legendBorderWidth: borderWidthNone,
     // 图例失效边框宽度
@@ -132,11 +133,11 @@ function getModelToken(aliasToken) {
     // x轴名称间距
     xAxisNameGap: axisNameSpace,
     // x轴名称颜色
-    xAxisNameColor: colorTextSecondary,
+    xAxisNameColor: colorTextName,
     // x轴名称字号
     xAxisNameFontSize: subtextFontSize,
     // x轴标签文本颜色
-    xAxisLabelColor: colorTextTertiary,
+    xAxisLabelColor: colorAxisLabel,
     // x轴标签文本字号
     xAxisLabelFontSize: subtextFontSize,
     // x轴轴线颜色
@@ -162,11 +163,11 @@ function getModelToken(aliasToken) {
     // y轴名称间距
     yAxisNameGap: axisNameSpace,
     // y轴名称颜色
-    yAxisNameColor: colorTextSecondary,
+    yAxisNameColor: colorTextName,
     // y轴名称字号
     yAxisNameFontSize: subtextFontSize,
     // y轴标签文本颜色
-    yAxisLabelColor: colorTextTertiary,
+    yAxisLabelColor: colorAxisLabel,
     // y轴标签文本字号
     yAxisLabelFontSize: subtextFontSize,
     // y轴轴线颜色
@@ -190,11 +191,11 @@ function getModelToken(aliasToken) {
 
     /** -----radar轴------ */
     // radar轴名称颜色
-    radarAxisNameColor: colorTextSecondary,
+    radarAxisNameColor: colorTextName,
     // radar轴名字号
     radarAxisNameFontSize: subtextFontSize,
     // radar轴标签文本颜色
-    radarAxisLabelColor: colorTextTertiary,
+    radarAxisLabelColor: colorAxisLabel,
     // radar轴标签文本字号
     radarAxisLabelFontSize: subtextFontSize,
     // radar轴线颜色
@@ -210,7 +211,7 @@ function getModelToken(aliasToken) {
     // radar轴刻度线类别
     radarAxisTickLineType: axisTickLineType,
     // radar轴分隔线颜色
-    radarSplitLineColor: colorAxisLineSecondary,
+    radarSplitLineColor: colorAxisSplitLineSecondary,
     // radar轴分隔线粗细
     radarSplitLineWidth: axisSplitLineWidth,
     // radar轴分隔线类别
@@ -218,7 +219,7 @@ function getModelToken(aliasToken) {
 
     /** -----极坐标系角度轴------ */
     // 角度轴标签文本颜色
-    angleAxisLabelColor: colorTextTertiary,
+    angleAxisLabelColor: colorAxisLabel,
     // 角度轴标签文本字号
     angleAxisLabelFontSize: subtextFontSize,
     // 角度轴轴线颜色
@@ -245,7 +246,7 @@ function getModelToken(aliasToken) {
     // 径向轴标签间距
     radiusAxisLabelGap: axisLabelSpace,
     // 径向轴标签颜色
-    radiusAxisLabelColor: colorTextTertiary,
+    radiusAxisLabelColor: colorAxisLabel,
     // 径向轴标签字号
     radiusAxisLabelFontSize: subtextFontSize,
     // 径向轴轴线颜色
@@ -261,7 +262,7 @@ function getModelToken(aliasToken) {
     // 径向轴刻度线类别
     radiusAxisTickLineType: axisTickLineType,
     // 径向轴分隔线颜色
-    radiusAxisSplitLineColor: colorAxisLineSecondary,
+    radiusAxisSplitLineColor: colorAxisSplitLineSecondary,
     // 径向轴分隔线粗细
     radiusAxisSplitLineWidth: axisSplitLineWidth,
     // 径向轴分隔线类别
@@ -269,9 +270,9 @@ function getModelToken(aliasToken) {
 
     /** -----tooltip------ */
     // tip背景
-    tooltipBg: colorBgSecondary,
+    tooltipBg: colorBgContainerSecondary,
     // tip文本颜色
-    tooltipTextColor: colorTextPrimary,
+    tooltipTextColor: colorLabel,
     // tip文本字号
     tooltipTextFontSize: textFontSize,
     // tip圆角
@@ -283,73 +284,68 @@ function getModelToken(aliasToken) {
     // tip坐标轴指示器线类别
     tooltipAxisPointerLineType: axisPointerLineType,
     // tip坐标轴指示器阴影
-    tooltipAxisPointerShadowColor: colorAxisPointerShadow,
+    tooltipAxisPointerShadowColor: colorShadowHover,
     // tip阴影
-    tooltipShadowColor: colorShadow,
+    tooltipShadowColor: colorShadowContainer,
     // tip阴影垂直方向偏移
-    tooltipShadowOffsetY: shadowOffsetY,
+    tooltipShadowOffsetY: shadowOffsetYContainer,
     // tip阴影模糊
-    tooltipShadowBlur: shadowBlur,
+    tooltipShadowBlur: shadowBlurContainer,
     // tip边框
     tooltipBorderWidth: borderWidthNone,
     // tip的padding
     tooltipPadding: paddingLG,
 
     /** -----visualMap------ */
-    // PiecesColor
-    visualMapPiecesColor: colorTextTransparent,
-    // dashColor
-    visualMapDashColor: colorDash,
-    // 以上两个属性用于线形图，后续要变更
     // 文本颜色
-    visualMapTextColor: colorTextPrimary,
+    visualMapTextColor: colorLabel,
     // 文本字号
     visualMapTextFontSize: labelFontSize,
 
-    /** -----markPoint------ */
-    // markPoint标签文本
-    markPointLabelColor: colorTextTransparent,
-
     /** ----- markLine------ */
     // 标记线粗细
-    markLineWidth,
+    markLineWidth: lineWidthSecondary,
     // 标记线高亮粗细
-    markLineEmphasisWidth,
+    markLineEmphasisWidth: lineWidthSecondary,
     // 标记线文本字号
     markLineLabelFontSize: labelFontSize,
-    // 标记线文本圆角
-    markLineLabelBorderRadius: borderRadius,
-    // 标记线文本Padding
-    markLineLabelPadding: [paddingSM, paddingSM * 2, paddingSM, paddingSM * 2],
-    // 标记线文本borderWidth
-    markLineLabelBorderWidth: borderWidthLG,
-
 
     /** ----- dataZoom------ */
     // dataZoom边框色
-    dataZoomBorderColor: colorBgTertiary,
+    dataZoomBorderColor: colorZoomBorder,
     // dataZoom背景色
-    dataZoomBackgroundColor: colorBgTertiary,
+    dataZoomBackgroundColor: colorZoomBg,
     // 手柄中心填充色
-    dataZoomHandleColor: colorBgQuaternary,
+    dataZoomHandleColor: colorZoomHandle,
     // 手柄外框色
-    dataZoomHandleBorderColor: colorBorderSecondary,
+    dataZoomHandleBorderColor: colorZoomHandleBorder,
     // 手柄阴影色
-    dataZoomHandleShadowColor: colorShadowSecondary,
+    dataZoomHandleShadowColor: colorShadowHandle,
     // 手柄hover时中心填充色
-    dataZoomEmphasisHandleColor: colorBgQuaternary,
+    dataZoomEmphasisHandleColor: colorZoomHandle,
     // 手柄hover时外框色
-    dataZoomEmphasisHandleBorderColor: colorBorderSecondary,
+    dataZoomEmphasisHandleBorderColor: colorZoomHandleBorder,
     // 选中区域外的线条颜色
-    dataBackgroundLineColor: colorFill,
+    dataZoomDataBackgroundLineColor: colorZoomDataAreaBorder,
     // 选中区域外的面积颜色
-    dataBackgroundAreaColor: colorFill,
-
+    dataZoomDataBackgroundAreaColor: colorZoomDataAreaFill,
+    // 数据区域的边框
+    dataZoomDataBackgroundLineWidth: zoomDataAreaBorderWidth,
+    // 选中区域数据颜色
+    dataZoomSelectedDataAreaColor: colorZoomSelectDataAreaFill,
+    // 选中区域边框颜色
+    dataZoomSelectedDataLineColor: colorZoomSelectDataAreaBorder,
+    // 选中区域填充颜色
+    dataZoomFillColor: colorZoomFill,
+    // 阴影y偏移
+    dataZoomHandleShadowOffsetY: shadowOffsetYHandle,
+    // 阴影模糊
+    dataZoomHandleShadowBlur: shadowBlurHandle,
     // min形态
     // dataZoom边框色
-    dataZoomBorderColorMini: colorBorderTransparent,
+    dataZoomBorderColorMini: colorNone,
     // 手柄阴影色
-    dataZoomHandleShadowColorMini: colorShadowTertiary,
+    dataZoomHandleShadowColorMini: colorShadowHandle,
 
     /** ----- animation------ */
     // 是否开启动画 

--- a/src/feature/token/factory/index.js
+++ b/src/feature/token/factory/index.js
@@ -28,7 +28,7 @@ function getToken(themeName) {
     ...color[themeName].colorSet,
     ...modelToken,
     ...chartsToken,
-    colorBoard:color[themeName].colorBoard,
+    colorBoard: color[themeName].colorBoard,
   };
 }
 

--- a/src/feature/token/theme/cloud/getAliasToken.js
+++ b/src/feature/token/theme/cloud/getAliasToken.js
@@ -9,21 +9,11 @@
  * A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
  *
  */
-import { codeToRGB } from '../../../../util/color';
+import getSceneToken from './getSceneToken';
 
 function getAliasToken(globalToken, light = true) {
+
   const {
-    colorGray0,
-    colorGray5,
-    colorGray30,
-    colorGray40,
-    colorGray50,
-    colorGray60,
-    colorGray80,
-    colorGray70,
-    colorGray90,
-    colorGray100,
-    colorTransparent,
     fontSizeBase,
     fontSizeMd,
     space2x,
@@ -32,7 +22,6 @@ function getAliasToken(globalToken, light = true) {
     fontSize4xl,
     lineTypeSolid,
     lineTypeDashedLG,
-    space6x,
     borderNone,
     borderBase,
     borderRadiusBase,
@@ -48,81 +37,120 @@ function getAliasToken(globalToken, light = true) {
     size2x,
   } = globalToken;
 
+  const {
+    colorBgMask,
+    colorBgPrimary,
+    colorBgSecondary,
+    colorBgPlaceholder,
+    colorBgHover,
+    colorBgHandle,
+    colorTextPrimary,
+    colorTextSecondary,
+    colorTextPlaceholder,
+    colorTextDisabled,
+    colorIconPrimary,
+    colorIconDisabled,
+    colorLine,
+    colorLineSecondary,
+    colorLineSeparator,
+    colorFillNone,
+    colorFill,
+    colorFillSelect,
+    colorFillSelectSecondary,
+    colorFillHover,
+    colorFillHandle,
+    colorBorder,
+    colorBorderSelect,
+    colorShadowPrimary,
+    colorShadowSecondary,
+    shadowOffsetYPrimary,
+    shadowOffsetYSecondary,
+    shadowBlurPrimary,
+    shadowBlurSecondary,
+  } = getSceneToken(globalToken, light)
+
   return {
-    //  初级底色 图表背景
-    colorBgPrimary: light ? colorGray0 : colorGray90, // 确定
-    // 次级背景色 tip背景
-    colorBgSecondary: light ? colorGray0 : colorGray80, // 确定
-    // datazoom背景色
-    colorBgTertiary: light ? colorGray5 : colorGray80,
-    //datazoom手柄填充背景和主要文本色一致
-    colorBgQuaternary: light ? colorGray90 : colorGray0,
-    // datazoom选中区域外的线条颜色和面积颜色
-    colorFill: light ? colorGray50 : colorGray70,
-    // symbol等填充颜色
-    colorFillSecondary: light ? colorGray0 : colorGray90,// 确定
-    // 主要文本色
-    colorTextPrimary: light ? colorGray90 : colorGray40, // 确定
-    // 次级文本色
-    colorTextSecondary: light ? colorGray60 : colorGray50, // 确定
-    // 三级文本色
-    colorTextTertiary: light ? colorGray60 : colorGray50, // 确定
-    // 禁用文本色
-    colorTextDisabled: light ? colorGray50 : colorGray60, // 确定
-    // 图标激活色（legend翻页的颜色）
-    colorIconPrimary: light ? colorGray60 : colorGray60, // 确定
-    // 控件失效色（legend失效的颜色）
-    colorInactive: light ? colorGray50 : colorGray80, // 确定
-    // 图标禁用色（legend翻页图标禁用的颜色）
-    colorIconDisabled: light ? colorGray50 : colorGray80, // 确定
-    // 坐标轴线颜色
-    colorAxisLine: light ? colorGray30 : colorGray80, // 确定
-    // 用于极坐标的径向轴和雷达坐标的分隔线颜色，和坐标轴线颜色保持一致，特殊处理专用
-    colorAxisLineSecondary: light ? colorGray30 : colorGray80, // 确定
-    // 刻度线颜色
-    colorAxisTickLine: light ? colorGray30 : colorGray80, // 确定
-    // 分隔线颜色
-    colorAxisSplitLine: light ? colorGray30 : colorGray80, // 确定
-    // 坐标轴指示器悬浮线
-    colorAxisPointerLine: light ? colorGray60 : colorGray70, // 确定
-    // 透明边框色
-    colorBorderTransparent: colorTransparent,
-    // 文本透明
-    colorTextTransparent: colorTransparent,
-    // 指示器阴影
-    colorAxisPointerShadow: light ? codeToRGB(colorGray90, 0.08) : codeToRGB(colorGray90, 0.08), //
-    // tip阴影
-    colorShadow: light ? codeToRGB(colorGray90, 0.08) : codeToRGB(colorGray90, 0.08), //
-    // datazoom手柄阴影
-    colorShadowSecondary: light ? codeToRGB(colorGray100, 0.04) : codeToRGB(colorGray100, 0.24),// 确定
-    // datazoom min手柄阴影
-    colorShadowTertiary: light ? codeToRGB(colorGray100, 0.08) : codeToRGB(colorGray100, 0.24),
-    // 边框颜色
-    colorBorder: light ? colorGray0 : colorGray90, // 确定
-    // 边框反选色
-    colorBorderInverse: light ? colorGray90 : colorGray0, // 确定
-    // datazoom手柄边框色 把手容器色
-    colorBorderSecondary: light ? colorGray0 : colorGray60,
-    // 禁用边框颜色和图表colorBgPrimary保持一致（聚合气泡图用todo）
-    colorBorderDisabled: light ? colorGray0 : colorGray90, // 确定
+    // -----------------------------------------------------颜色-------------------------------------------------------------------------
+    // 卡片背景
+    colorBgContainer: colorBgPrimary,
+    // tip背景
+    colorBgContainerSecondary: colorBgSecondary,
+    // 悬浮背景
+    colorBgContainerHover: colorBgHover,
+    // 标题颜色
+    colorTitle: colorTextPrimary,
+    // 副标题颜色
+    colorSubTitle: colorTextSecondary,
+    // 名称文本（轴名称，legend名称等）
+    colorTextName: colorTextPlaceholder,
+    // 轴label
+    colorAxisLabel: colorTextPlaceholder,
     // label颜色
-    colorLabel: light ? colorGray90 : colorGray40, // 确定
-    // label禁用颜色（和文本禁用色保持一致）
-    colorLabelDisabled: light ? colorGray50 : colorGray60, // 确定
-    // 虚线的颜色
-    colorDash: light ? colorGray0 : colorGray90,
-    // 背景透明
-    colorBgTransparent: colorTransparent,
-    // 无数据占位背景
-    colorBgEmpty: light ? colorGray30 : colorGray80, // 确定
-    // labelLine颜色
-    colorLabelLine: light ? colorGray90 : colorGray40, // 确定
-    // 线透明
-    colorLineTransparent: colorTransparent,
-    // tip阴影垂直偏移
-    shadowOffsetY: space2x,
+    colorLabel: colorTextPrimary,
+    // 进度图专用name名称
+    colorLabelSecondary: colorTextPlaceholder,
+    // label禁用颜色
+    colorLabelDisabled: colorTextDisabled,
+    // 图标色
+    colorIcon: colorIconPrimary,
+    // 图标失效色
+    colorIconInactive: colorIconDisabled,
+    // 坐标轴线颜色
+    colorAxisLine: colorLine,
+    // 刻度线颜色
+    colorAxisTickLine: colorLineSecondary,
+    // 分隔线颜色
+    colorAxisSplitLine: colorLine,
+    // 用于极坐标的径向轴和雷达坐标的分隔线颜色，和坐标轴线颜色保持一致，特殊处理专用
+    colorAxisSplitLineSecondary: colorLine,
+    // 坐标轴指示器悬浮线
+    colorAxisPointerLine: colorLineSeparator,
+    // 分隔线
+    colorSeparatorLine: colorLineSeparator,
+    // lableline
+    colorLabelLine: colorLine,
+    // 无色
+    colorNone: colorFillNone,
+    // 占位色
+    colorPlaceholder: colorBgPlaceholder,
+    // 遮盖色
+    colorMask: colorBgMask,
+    // zoom背景色
+    colorZoomBg: colorBgHover,
+    // zoom border颜色
+    colorZoomBorder: colorFillNone,
+    // zoom 数据区域 border
+    colorZoomDataAreaBorder: colorBorder,
+    // zoom 数据区域填充
+    colorZoomDataAreaFill: colorFill,
+    // zoom 选中区域填充
+    colorZoomFill: colorFillSelect,
+    // zoom 选中区域数据border
+    colorZoomSelectDataAreaBorder: colorBorderSelect,
+    // zoom 选中区域数据填充
+    colorZoomSelectDataAreaFill: colorFillSelectSecondary,
+    // zoom 手柄颜色
+    colorZoomHandle: colorFillHandle,
+    // zoom 手柄border
+    colorZoomHandleBorder: colorBgHandle,
+    // hover阴影
+    colorShadowHover: colorFillHover,
+    // tip阴影
+    colorShadowContainer: colorShadowPrimary,
+    // 手柄阴影
+    colorShadowHandle: colorShadowSecondary,
+    // symbol hover填充
+    symbolFillHover: colorBgMask,
+    // ---------------------------------------------------阴影-------------------------------------------------
+    // tip阴影offsetY
+    shadowOffsetYContainer: shadowOffsetYPrimary,
+    // 手柄阴影offsetY
+    shadowOffsetYHandle: shadowOffsetYSecondary,
     // tip阴影模糊
-    shadowBlur: space6x,
+    shadowBlurContainer: shadowBlurPrimary,
+    // 手柄阴影模糊
+    shadowBlurHandle: shadowBlurSecondary,
+    // ------------------------------------------------------------------字号---------------------------------------------------
     // 主文本字号
     textFontSize: fontSizeMd, // 确定
     // 次级文本字号
@@ -131,6 +159,9 @@ function getAliasToken(globalToken, light = true) {
     titleFontSize: fontSize4xl,
     // 副标题文本字号
     subtitleFontSize: fontSizeLg,
+    // label字号
+    labelFontSize: fontSizeBase,
+    // ----------------------------------------------线宽---------------------------------------------------------
     // 坐标轴 1
     axisLineWidth: borderBase,
     // 用于极坐标系和雷达坐标系
@@ -141,6 +172,13 @@ function getAliasToken(globalToken, light = true) {
     axisSplitLineWidth: borderBase,
     // 坐标轴指示器的标线线宽 1
     axisPointerLineWidth: borderBase,
+    // 常规线宽
+    lineWidth: border2x,
+    // 二级线宽
+    lineWidthSecondary: borderBase,
+    // 无线宽
+    lineWidthNone: borderNone,
+    // -------------------------------------------------------------------线型-------------------------------------------------------------------
     // 坐标轴类型
     axisLineType: lineTypeSolid,
     // 刻度线类型
@@ -151,52 +189,15 @@ function getAliasToken(globalToken, light = true) {
     axisSplitLineTypeSecondary: lineTypeSolid,
     // 坐标轴指示器标线类型
     axisPointerLineType: lineTypeSolid,
+    // ---------------------------------------------------------------------间距------------------------------------------------------------------------------- 
     // 坐标轴名称间距
     axisNameSpace: space2x,
     // 坐标轴文本间距
     axisLabelSpace: spaceBase,
-    // 标识线宽度
-    markLineWidth: borderBase,
-    // 标识线高亮宽度
-    markLineEmphasisWidth: borderBase,
-    //  border 0
-    borderWidthNone: borderNone,
     // 标题文本间距
     titleSpace: space2x,
     // 容器的间距
     containerGap: spaceBase,
-    // 容器的圆角
-    containerBoderRadius: borderRadiusBase,
-    // 图元 
-    symbolSize: size3x,
-    // 图元  线形图用
-    symbolSizeSM: size2x,
-    // 图元的边框0
-    symbolBorderWidthNone: borderNone,
-    // 图元的边框
-    symbolBorderWidth: border2x,
-    // 柱条的宽度
-    barWidth: size2x,
-    // 堆叠进度图宽度 20
-    barWidthLG: size5x,
-    // label字号
-    labelFontSize: fontSizeBase,
-    // labelLine的长度
-    labelLineLength: size6x,
-    // 边框 细
-    borderWidth: borderBase,
-    // 边框
-    borderWidthLG: border2x,
-    // 圆角 0
-    borderRadiusNone,
-    // 圆角 小
-    borderRadius: borderRadiusBase,
-    lineWidth: border2x,
-    lineWidthNone: borderNone,
-    // 图例单元尺寸
-    legendItemSize: size05x,
-    // 图例圆形单元尺寸
-    legendCircleItemSize: size2x,
     // 图例的间距
     legendSpace: space8x,
     // 无padding
@@ -204,6 +205,41 @@ function getAliasToken(globalToken, light = true) {
     paddingSM: spaceBase,
     padding: space2x,
     paddingLG: space4x,
+    // -----------------------------------------------------------------边框------------------------------------------------------------------------------
+    // zoom数据区域边框
+    zoomDataAreaBorderWidth: borderBase,
+    // 边框 细
+    borderWidth: borderBase,
+    // 边框
+    borderWidthLG: border2x,
+    //  border 0
+    borderWidthNone: borderNone,
+    // 图元的边框0
+    symbolBorderWidthNone: borderNone,
+    // 图元的边框
+    symbolBorderWidth: border2x,
+    // -------------------------------------------------------------size----------------------------------------------------------------------------------------
+    // 图元 
+    symbolSize: size3x,
+    // 图元  线形图用
+    symbolSizeSM: size2x,
+    // 柱条的宽度
+    barWidth: size2x,
+    // 堆叠进度图宽度 20
+    barWidthLG: size5x,
+    // 图例单元尺寸
+    legendItemSize: size05x,
+    // 图例圆形单元尺寸
+    legendCircleItemSize: size2x,
+    // labelLine的长度
+    labelLineLength: size6x,
+    // ------------------------------------------------圆角---------------------------------------------------
+    // 容器的圆角
+    containerBoderRadius: borderRadiusBase,
+    // 圆角 0
+    borderRadiusNone,
+    // 圆角 小
+    borderRadius: borderRadiusBase,
   };
 }
 

--- a/src/feature/token/theme/cloud/getSceneToken.js
+++ b/src/feature/token/theme/cloud/getSceneToken.js
@@ -1,0 +1,74 @@
+import { codeToRGB } from '../../../../util/color';
+// cloud黑白主题为两套不同的色板,灰阶命名黑白主题相反
+function getSceneToken(globalToken, light = true) {
+    const {
+        colorGray0,
+        colorGray10,
+        colorGray15,
+        colorGray20,
+        colorGray30,
+        colorGray40,
+        colorGray50,
+        colorGray60,
+        colorGray70,
+        colorGray90,
+        colorGray100,
+        colorTransparent,
+        colorBoard,
+        spaceBase,
+        space05x,
+        space4x
+    } = globalToken;
+
+    return {
+        // 用于实现一些遮盖场景
+        colorBgMask: light ? colorGray0 : colorGray10,
+        // 初级底色 (卡片)
+        colorBgPrimary: light ? colorGray0 : colorGray10,
+        // 次级背景色 tip背景
+        colorBgSecondary: light ? colorGray0 : colorGray15,
+        // 占位背景色
+        colorBgPlaceholder: light ? colorGray30 : colorGray15,
+        // datazoom背景
+        colorBgHover: light ? colorGray10 : codeToRGB(colorGray100, 0.1),
+        // datazoom  handle border todo 
+        colorBgHandle: light ? colorBoard.blue.colorBlue60 : colorBoard.blue.colorBlue70,
+        // 主要文本色
+        colorTextPrimary: colorGray90,
+        // 次要文本色
+        colorTextSecondary: colorGray70,
+        // 占位文本色
+        colorTextPlaceholder: light ? colorGray60 : colorGray50,
+        // 禁用文本色
+        colorTextDisabled: colorGray50,
+        // 图标色
+        colorIconPrimary: light ? colorGray60 : colorGray70,
+        // 图标禁用色
+        colorIconDisabled: colorGray50,
+        colorLine: colorGray20,
+        colorLineSecondary: light ? colorGray40 : colorGray20,
+        //分隔线
+        colorLineSeparator: colorGray90,
+        colorFillNone: colorTransparent,
+        // datzoom 未选中数据  fill
+        colorFill: light ? codeToRGB(colorGray100, 0.05) : codeToRGB(colorGray100, 0.1),
+        // datzoom  选中区域 fill todo
+        colorFillSelect: light ? codeToRGB(colorBoard.blue.colorBlue60, 0.2) : codeToRGB(colorBoard.blue.colorBlue70, 0.2),
+        // datzoom  选中数据 fill todo
+        colorFillSelectSecondary: light ? colorBoard.blue.colorBlue30 : colorBoard.blue.colorBlue100,
+        // hover阴影
+        colorFillHover: light ? codeToRGB(colorGray100, 0.05) : codeToRGB(colorGray100, 0.1),
+        // datzoom handle 填充
+        colorFillHandle: light ? colorGray0 : colorGray100,
+        colorBorder: light ? colorGray50 : colorGray40,
+        colorBorderSelect: light ? colorBoard.blue.colorBlue60 : colorBoard.blue.colorBlue60,
+        colorShadowPrimary: light ? codeToRGB(colorGray100, 0.16) : codeToRGB(colorGray0, 0.08),
+        colorShadowSecondary: light ? codeToRGB(colorGray100, 0.08) : codeToRGB(colorGray0, 0.08),
+        shadowOffsetYPrimary: spaceBase,
+        shadowOffsetYSecondary: space05x,
+        shadowBlurPrimary: space4x,
+        shadowBlurSecondary: spaceBase,
+    }
+}
+
+export default getSceneToken

--- a/src/feature/token/theme/hdesign/getAliasToken.js
+++ b/src/feature/token/theme/hdesign/getAliasToken.js
@@ -9,28 +9,16 @@
  * A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
  *
  */
-import { codeToRGB } from '../../../../util/color';
+import getSceneToken from './getSceneToken';
 
 function getAliasToken(globalToken, light = true) {
+
   const {
-    colorGray0,
-    colorGray5,
-    colorGray10,
-    colorGray20,
-    colorGray30,
-    colorGray40,
-    colorGray50,
-    colorGray60,
-    colorGray70,
-    colorGray80,
-    colorGray90,
-    colorGray100,
     fontSizeBase,
     fontSizeMd,
     space2x,
     spaceBase,
     lineTypeSolid,
-    colorTransparent,
     borderNone,
     borderBase,
     borderRadiusBase,
@@ -38,7 +26,6 @@ function getAliasToken(globalToken, light = true) {
     fontSizeLg,
     borderRadiusNone,
     fontSize4xl,
-    space6x,
     size3x,
     size2x,
     size4x,
@@ -51,82 +38,120 @@ function getAliasToken(globalToken, light = true) {
     borderRadiusLg,
   } = globalToken;
 
+  const {
+    colorBgMask,
+    colorBgPrimary,
+    colorBgSecondary,
+    colorBgPlaceholder,
+    colorBgHover,
+    colorBgHandle,
+    colorTextPrimary,
+    colorTextSecondary,
+    colorTextPlaceholder,
+    colorTextDisabled,
+    colorIconPrimary,
+    colorIconDisabled,
+    colorLine,
+    colorLineSecondary,
+    colorLineSeparator,
+    colorFillNone,
+    colorFill,
+    colorFillSelect,
+    colorFillSelectSecondary,
+    colorFillHover,
+    colorFillHandle,
+    colorBorder,
+    colorBorderSelect,
+    colorShadowPrimary,
+    colorShadowSecondary,
+    shadowOffsetYPrimary,
+    shadowOffsetYSecondary,
+    shadowBlurPrimary,
+    shadowBlurSecondary,
+  } = getSceneToken(globalToken, light)
+
   return {
-    //  初级底色  图表背景
-    colorBgPrimary: light ? colorGray0 : codeToRGB(colorGray5, 0.1), // 确定
-    // 次级背景色  tip背景
-    colorBgSecondary: light ? colorGray0 : colorGray70, // 确定
-    // datazoom背景色
-    colorBgTertiary: light ? colorGray5 : colorGray80,
-    //datazoom手柄填充背景和主要文本色一致
-    colorBgQuaternary: light ? colorGray90 : colorGray0,
-    // datazoom选中区域外的线条颜色和面积颜色
-    colorFill: light ? colorGray20 : colorGray70,
-    // symbol等填充颜色
-    colorFillSecondary: light ? colorGray0 : colorGray90,// 确定
-    // 主要文本色
-    colorTextPrimary: light ? colorGray90 : colorGray0, // 确定
-    // 次级文本色
-    colorTextSecondary: light ? colorGray50 : colorGray20, // 确定
-    // 三级文本色
-    colorTextTertiary: light ? colorGray30 : colorGray40,
-    // 禁用文本色
-    colorTextDisabled: light ? colorGray20 : colorGray60, // 确定
-    // 图标激活色（legend翻页的颜色）
-    colorIconPrimary: light ? colorGray70 : colorGray20, // 确定
-    // 控件失效色（legend失效的颜色）
-    colorInactive: light ? colorGray10 : colorGray80, // 确定
-    // 图标禁用色（legend翻页图标禁用的颜色）
-    colorIconDisabled: light ? colorGray10 : colorGray80, // 确定
-    // 坐标轴线颜色
-    colorAxisLine: light ? colorGray10 : colorGray70, // 确定
-    // 用于极坐标的径向轴和雷达坐标的分隔线颜色，和坐标轴线颜色保持一致，特殊处理专用
-    colorAxisLineSecondary: light ? colorGray10 : colorGray70, // 确定
-    // 刻度线颜色
-    colorAxisTickLine: light ? colorGray10 : colorGray70, // 确定
-    // 分隔线颜色
-    colorAxisSplitLine: light ? colorGray5 : colorGray80, // 确定
-    // 坐标轴指示器悬浮线
-    colorAxisPointerLine: light ? colorGray10 : colorGray70, // 确定
-    // 透明边框色
-    colorBorderTransparent: colorTransparent,
-    // 文本透明
-    colorTextTransparent: colorTransparent,
-    // 指示器阴影
-    colorAxisPointerShadow: light ? codeToRGB(colorGray10, 0.5) : codeToRGB(colorGray5, 0.05), // 确定
-    // tip阴影
-    colorShadow: light ? codeToRGB(colorGray90, 0.08) : codeToRGB(colorGray100, 0.5), // 确定
-    // datazoom手柄阴影
-    colorShadowSecondary: light ? codeToRGB(colorGray100, 0.04) : codeToRGB(colorGray100, 0.24),// 确定
-    // datazoom min手柄阴影
-    colorShadowTertiary: light ? codeToRGB(colorGray100, 0.08) : codeToRGB(colorGray100, 0.24),// 确定
-    // 边框颜色
-    colorBorder: light ? colorGray0 : colorGray90, // 确定
-    // 边框反选色
-    colorBorderInverse: light ? colorGray90 : colorGray0, // 确定
-    // datazoom手柄边框色 把手容器色
-    colorBorderSecondary: light ? colorGray0 : colorGray60,
-    // 以下和规范还未确认
-    // 禁用边框颜色和图表colorBgPrimary保持一致（聚合气泡图用todo）
-    colorBorderDisabled: light ? colorGray0 : codeToRGB(colorGray5, 0.1),
+    // -----------------------------------------------------颜色-------------------------------------------------------------------------
+    // 卡片背景
+    colorBgContainer: colorBgPrimary,
+    // tip背景
+    colorBgContainerSecondary: colorBgSecondary,
+    // 悬浮背景
+    colorBgContainerHover: colorBgHover,
+    // 标题颜色
+    colorTitle: colorTextPrimary,
+    // 副标题颜色
+    colorSubTitle: colorTextSecondary,
+    // 名称文本（轴名称，legend名称等）
+    colorTextName: colorTextSecondary,
+    // 轴label
+    colorAxisLabel: colorTextPlaceholder,
     // label颜色
-    colorLabel: light ? colorGray90 : colorGray5,
-    // label禁用颜色（和文本禁用色保持一致）
-    colorLabelDisabled: light ? colorGray20 : colorGray60,
-    // 虚线的颜色
-    colorDash: light ? colorGray0 : colorGray90,
-    // 背景透明
-    colorBgTransparent: colorTransparent,
-    // 无数据占位背景
-    colorBgEmpty: light ? colorGray5 : codeToRGB(colorGray5, 0.05),
-    // labelLine颜色
-    colorLabelLine: light ? colorGray10 : codeToRGB(colorGray5, 0.15),
-    // 线透明
-    colorLineTransparent: colorTransparent,
-    // tip阴影垂直偏移
-    shadowOffsetY: space2x,
+    colorLabel: colorTextPrimary,
+    // 进度图专用name名称和pie图使用
+    colorLabelSecondary: colorTextPrimary,
+    // label禁用颜色
+    colorLabelDisabled: colorTextDisabled,
+    // 图标色
+    colorIcon: colorIconPrimary,
+    // 图标失效色
+    colorIconInactive: colorIconDisabled,
+    // 坐标轴线颜色
+    colorAxisLine: colorLine,
+    // 刻度线颜色
+    colorAxisTickLine: colorLine, // 确定
+    // 分隔线颜色
+    colorAxisSplitLine: colorLineSecondary, // 确定
+    // 用于极坐标的径向轴和雷达坐标的分隔线颜色，和坐标轴线颜色保持一致，特殊处理专用
+    colorAxisSplitLineSecondary: colorLine,
+    // 坐标轴指示器悬浮线
+    colorAxisPointerLine: colorLineSeparator,
+    // 分隔线
+    colorSeparatorLine: colorLineSeparator,
+    // lableline
+    colorLabelLine: colorLineSeparator,
+    // 无色
+    colorNone: colorFillNone,
+    // 占位色
+    colorPlaceholder: colorBgPlaceholder,
+    // 遮盖色
+    colorMask: colorBgMask,
+    // zoom背景色
+    colorZoomBg: colorBgHover,
+    // zoom border颜色
+    colorZoomBorder: colorBgHover,
+    // zoom 数据区域 border
+    colorZoomDataAreaBorder: colorBorder,
+    // zoom 数据区域填充
+    colorZoomDataAreaFill: colorFill,
+    // zoom 选中区域填充
+    colorZoomFill: colorFillSelect,
+    // zoom 选中区域数据border
+    colorZoomSelectDataAreaBorder: colorBorderSelect,
+    // zoom 选中区域数据填充
+    colorZoomSelectDataAreaFill: colorFillSelectSecondary,
+    // zoom 手柄颜色
+    colorZoomHandle: colorFillHandle,
+    // zoom 手柄border
+    colorZoomHandleBorder: colorBgHandle,
+    // hover阴影
+    colorShadowHover: colorFillHover,
+    // tip阴影
+    colorShadowContainer: colorShadowPrimary,
+    // 手柄阴影
+    colorShadowHandle: colorShadowSecondary,
+    // symbol hover填充
+    symbolFillHover: colorBgMask,
+    // ---------------------------------------------------阴影-------------------------------------------------
+    // tip阴影offsetY
+    shadowOffsetYContainer: shadowOffsetYPrimary,
+    // 手柄阴影offsetY
+    shadowOffsetYHandle: shadowOffsetYSecondary,
     // tip阴影模糊
-    shadowBlur: space6x,
+    shadowBlurContainer: shadowBlurPrimary,
+    // 手柄阴影模糊
+    shadowBlurHandle: shadowBlurSecondary,
+    // ------------------------------------------------------------------字号---------------------------------------------------
     // 主文本字号
     textFontSize: fontSizeMd,
     // 次级文本字号
@@ -135,6 +160,9 @@ function getAliasToken(globalToken, light = true) {
     titleFontSize: fontSize4xl,
     // 副标题文本字号
     subtitleFontSize: fontSizeLg,
+    // label字号
+    labelFontSize: fontSizeBase,
+    // ----------------------------------------------线宽---------------------------------------------------------
     // 坐标轴线宽 2
     axisLineWidth: border2x,
     // 用于极坐标系和雷达坐标系
@@ -145,6 +173,13 @@ function getAliasToken(globalToken, light = true) {
     axisSplitLineWidth: borderBase,
     // 坐标轴指示器的标线线宽 1
     axisPointerLineWidth: borderBase,
+    // 常规线宽
+    lineWidth: border2x,
+    // 二级线宽
+    lineWidthSecondary: borderBase,
+    // 无线宽
+    lineWidthNone: borderNone,
+    // -------------------------------------------------------------------线型-------------------------------------------------------------------
     // 坐标轴类型
     axisLineType: lineTypeSolid,
     // 刻度线类型
@@ -155,52 +190,15 @@ function getAliasToken(globalToken, light = true) {
     axisSplitLineTypeSecondary: lineTypeSolid,
     // 坐标轴指示器标线类型
     axisPointerLineType: lineTypeSolid,
+    // ---------------------------------------------------------------------间距-------------------------------------------------------------------------------
     // 坐标轴名称间距
     axisNameSpace: space2x,
     // 坐标轴文本间距
     axisLabelSpace: spaceBase,
-    // 标识线宽度
-    markLineWidth: borderBase,
-    // 标识线高亮宽度
-    markLineEmphasisWidth: borderBase,
-    //  border 0
-    borderWidthNone: borderNone,
     // 标题文本间距
     titleSpace: space2x,
     // 容器的间距
     containerGap: spaceBase,
-    // 容器的圆角
-    containerBoderRadius: borderRadiusLg,
-    // 图元 
-    symbolSize: size3x,
-    // 图元  线形图用
-    symbolSizeSM: size2x,
-    // 图元的边框0
-    symbolBorderWidthNone: borderNone,
-    // 图元的边框
-    symbolBorderWidth: border2x,
-    // 柱条的宽度
-    barWidth: size4x,
-    // 堆叠进度图宽度 20
-    barWidthLG: size5x,
-    // label字号
-    labelFontSize: fontSizeBase,
-    // labelLine的长度
-    labelLineLength: size6x,
-    // 边框 细
-    borderWidth: borderBase,
-    // 边框
-    borderWidthLG: border2x,
-    // 圆角 0
-    borderRadiusNone,
-    // 圆角 小
-    borderRadius: borderRadiusBase,
-    lineWidth: border2x,
-    lineWidthNone: borderNone,
-    // 图例单元尺寸
-    legendItemSize: size05x,
-    // 图例圆形单元尺寸
-    legendCircleItemSize: size2x,
     // 图例的间距
     legendSpace: space8x,
     // 无padding
@@ -208,6 +206,41 @@ function getAliasToken(globalToken, light = true) {
     paddingSM: spaceBase,
     padding: space2x,
     paddingLG: space4x,
+    // -----------------------------------------------------------------边框------------------------------------------------------------------------------
+    // zoom数据区域边框
+    zoomDataAreaBorderWidth: borderBase,
+    // 边框 细
+    borderWidth: borderBase,
+    // 边框
+    borderWidthLG: border2x,
+    //  border 0
+    borderWidthNone: borderNone,
+    // 图元的边框0
+    symbolBorderWidthNone: borderNone,
+    // 图元的边框
+    symbolBorderWidth: border2x,
+    // -------------------------------------------------------------size----------------------------------------------------------------------------------------
+    // 图元 
+    symbolSize: size3x,
+    // 图元  线形图用
+    symbolSizeSM: size2x,
+    // 柱条的宽度
+    barWidth: size4x,
+    // 堆叠进度图宽度 20
+    barWidthLG: size5x,
+    // 图例单元尺寸
+    legendItemSize: size05x,
+    // 图例圆形单元尺寸
+    legendCircleItemSize: size2x,
+    // labelLine的长度
+    labelLineLength: size6x,
+    // ------------------------------------------------圆角---------------------------------------------------
+    // 容器的圆角
+    containerBoderRadius: borderRadiusLg,
+    // 圆角 0
+    borderRadiusNone,
+    // 圆角 小
+    borderRadius: borderRadiusBase,
   };
 }
 

--- a/src/feature/token/theme/hdesign/getSceneToken.js
+++ b/src/feature/token/theme/hdesign/getSceneToken.js
@@ -1,0 +1,75 @@
+import { codeToRGB } from '../../../../util/color';
+
+function getSceneToken(globalToken, light = true) {
+    const {
+        colorGray0,
+        colorGray5,
+        colorGray10,
+        colorGray20,
+        colorGray30,
+        colorGray40,
+        colorGray50,
+        colorGray60,
+        colorGray70,
+        colorGray80,
+        colorGray90,
+        colorGray100,
+        colorTransparent,
+        colorBoard,
+        space2x,
+        space3x,
+        space6x,
+        spaceNone,
+    } = globalToken;
+    return {
+        // 用于实现一些遮盖场景
+        colorBgMask: light ? colorGray0 : colorGray90,
+        //  初级底色 (卡片)
+        colorBgPrimary: light ? colorGray0 : codeToRGB(colorGray5, 0.1),
+        // 次级背景色 (tip)
+        colorBgSecondary: light ? colorGray0 : colorGray70,
+        // 占位背景色
+        colorBgPlaceholder: light ? colorGray5 : codeToRGB(colorGray5, 0.05),
+        //datazoom背景
+        colorBgHover: light ? colorGray5 : colorGray80,
+        // datazoom  handle border
+        colorBgHandle: light ? colorGray0 : colorGray60,
+        // 主要文本色
+        colorTextPrimary: light ? colorGray90 : colorGray0,
+        // 次要文本色
+        colorTextSecondary: light ? colorGray50 : colorGray20,
+        // 占位文本色
+        colorTextPlaceholder: light ? colorGray30 : colorGray40,
+        // 禁用文本色
+        colorTextDisabled: light ? colorGray20 : colorGray40,
+        // 图标色
+        colorIconPrimary: light ? colorGray90 : colorGray10,
+        // 图标失效色
+        colorIconDisabled: light ? colorGray20 : colorGray40,
+        colorLine: light ? colorGray10 : colorGray70,
+        colorLineSecondary: light ? colorGray5 : colorGray80,
+        //分隔线
+        colorLineSeparator: light ? colorGray10 : colorGray70,
+        colorFillNone: colorTransparent,
+        // datzoom 未选中数据  fill
+        colorFill: light ? colorGray10 : colorGray70,
+        // datzoom  选中区域 fill
+        colorFillSelect: codeToRGB(colorBoard.blue.colorBlue50, 0.1),
+        // datzoom  选中数据 fill
+        colorFillSelectSecondary: light ? codeToRGB(colorBoard.blue.colorBlue30, 0.2) : codeToRGB(colorBoard.blue.colorBlue70, 0.3),
+        // hover阴影
+        colorFillHover: light ? codeToRGB(colorGray90, 0.05) : codeToRGB(colorGray5, 0.2),
+        // datzoom handle 填充
+        colorFillHandle: light ? colorGray90 : colorGray10,
+        colorBorder: light ? colorGray10 : colorGray70,
+        colorBorderSelect: light ? codeToRGB(colorBoard.blue.colorBlue30, 0.2) : codeToRGB(colorBoard.blue.colorBlue70, 0.3),
+        colorShadowPrimary: light ? codeToRGB(colorGray100, 0.08) : codeToRGB(colorGray100, 0.5),
+        colorShadowSecondary: light ? codeToRGB(colorGray100, 0.08) : codeToRGB(colorGray100, 0.5),
+        shadowOffsetYPrimary: space2x,
+        shadowOffsetYSecondary: spaceNone,
+        shadowBlurPrimary: space6x,
+        shadowBlurSecondary: space3x,
+    }
+}
+
+export default getSceneToken

--- a/src/feature/token/theme/ict/getAliasToken.js
+++ b/src/feature/token/theme/ict/getAliasToken.js
@@ -9,26 +9,17 @@
  * A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
  *
  */
-import { codeToRGB } from '../../../../util/color';
+
+import getSceneToken from './getSceneToken';
 
 function getAliasToken(globalToken, light = true) {
+
   const {
-    colorGray0,
-    colorGray5,
-    colorGray10,
-    colorGray20,
-    colorGray50,
-    colorGray60,
-    colorGray70,
-    colorGray80,
-    colorGray90,
-    colorGray100,
     fontSizeBase,
     fontSizeMd,
     space2x,
     spaceBase,
     lineTypeSolid,
-    colorTransparent,
     borderNone,
     borderBase,
     borderRadiusBase,
@@ -36,7 +27,6 @@ function getAliasToken(globalToken, light = true) {
     fontSizeLg,
     borderRadiusNone,
     fontSize4xl,
-    space6x,
     size05x,
     size3x,
     size2x,
@@ -47,81 +37,120 @@ function getAliasToken(globalToken, light = true) {
     size5x,
   } = globalToken;
 
+  const {
+    colorBgMask,
+    colorBgPrimary,
+    colorBgSecondary,
+    colorBgPlaceholder,
+    colorBgHover,
+    colorTextPrimary,
+    colorTextSecondary,
+    colorTextPlaceholder,
+    colorTextDisabled,
+    colorIconPrimary,
+    colorIconDisabled,
+    colorLine,
+    colorLineSecondary,
+    colorLineSeparator,
+    colorFillNone,
+    colorFill,
+    colorFillSelect,
+    colorFillSelectSecondary,
+    colorFillHover,
+    colorBorder,
+    colorBorderSelect,
+    colorFillHandle,
+    colorBgHandle,
+    colorShadowPrimary,
+    colorShadowSecondary,
+    shadowOffsetYPrimary,
+    shadowOffsetYSecondary,
+    shadowBlurPrimary,
+    shadowBlurSecondary,
+  } = getSceneToken(globalToken, light)
+
   return {
-    //  初级底色 图表背景
-    colorBgPrimary: light ? colorGray0 : colorGray90, // 确定
-    // 次级背景色 tip背景
-    colorBgSecondary: light ? colorGray0 : colorGray70,
-    // datazoom背景色
-    colorBgTertiary: light ? colorGray5 : colorGray80,
-    // datazoom手柄填充背景和主要文本色一致
-    colorBgQuaternary: light ? colorGray90 : colorGray0,
-    // datazoom选中区域外的线条颜色和面积颜色
-    colorFill: light ? colorGray20 : colorGray70,
-    // symbol等填充颜色
-    colorFillSecondary: light ? colorGray0 : colorGray90,// 确定
-    // 主要文本色
-    colorTextPrimary: light ? colorGray90 : colorGray5, // 确定
-    // 次级文本色
-    colorTextSecondary: light ? colorGray60 : colorGray20, // 确定
-    // 三级文本色
-    colorTextTertiary: light ? colorGray60 : colorGray20, // 确定
-    // 禁用文本色
-    colorTextDisabled: light ? codeToRGB(colorGray90, 0.3) : codeToRGB(colorGray10, 0.3), // 确定
-    // 图标激活色（legend翻页的颜色）
-    colorIconPrimary: light ? colorGray90 : colorGray10, // 确定
-    // 控件失效色（legend失效的颜色）
-    colorInactive: light ? colorGray20 : colorGray50, // 确定
-    // 图标禁用色（legend翻页图标禁用的颜色）
-    colorIconDisabled: light ? codeToRGB(colorGray90, 0.3) : codeToRGB(colorGray10, 0.3), // 确定
-    // 坐标轴线颜色
-    colorAxisLine: light ? colorGray10 : codeToRGB(colorGray10, 0.1), // 确定
-    // 用于极坐标的径向轴和雷达坐标的分隔线颜色，和坐标轴线颜色保持一致，特殊处理专用
-    colorAxisLineSecondary: light ? colorGray10 : codeToRGB(colorGray10, 0.1), // 确定
-    // 刻度线颜色
-    colorAxisTickLine: light ? colorGray10 : codeToRGB(colorGray10, 0.1), // 确定
-    // 分隔线颜色
-    colorAxisSplitLine: light ? codeToRGB(colorGray90, 0.1) : codeToRGB(colorGray10, 0.1), // 确定
-    // 坐标轴指示器悬浮线
-    colorAxisPointerLine: light ? colorGray20 : colorGray50, // 确定
-    // 透明边框色
-    colorBorderTransparent: colorTransparent,
-    // 文本透明
-    colorTextTransparent: colorTransparent,
-    // 指示器阴影
-    colorAxisPointerShadow: light ? codeToRGB(colorGray90, 0.05) : codeToRGB(colorGray10, 0.08),
-    // tip阴影
-    colorShadow: light ? codeToRGB(colorGray100, 0.16) : codeToRGB(colorGray100, 0.5),
-    // datazoom手柄阴影
-    colorShadowSecondary: light ? codeToRGB(colorGray100, 0.04) : codeToRGB(colorGray100, 0.24),// 确定
-    // datazoom min手柄阴影
-    colorShadowTertiary: light ? codeToRGB(colorGray100, 0.08) : codeToRGB(colorGray100, 0.24),// 确定
-    // 边框颜色
-    colorBorder: light ? colorGray0 : colorGray90,
-    // 边框反选色
-    colorBorderInverse: light ? colorGray90 : colorGray0, // 确定
-    // datazoom手柄边框色 把手容器色
-    colorBorderSecondary: light ? colorGray0 : colorGray70,
-    // 禁用边框颜色和图表colorBgPrimary保持一致（聚合气泡图用todo）
-    colorBorderDisabled: light ? colorGray0 : colorGray90, // 确定
+    // -----------------------------------------------------颜色-------------------------------------------------------------------------
+    // 卡片背景
+    colorBgContainer: colorBgPrimary,
+    // tip背景
+    colorBgContainerSecondary: colorBgSecondary,
+    // 悬浮背景
+    colorBgContainerHover: colorBgHover,
+    // 标题颜色
+    colorTitle: colorTextPrimary,
+    // 副标题颜色
+    colorSubTitle: colorTextSecondary,
+    // 名称文本（轴名称，legend名称等）
+    colorTextName: colorTextSecondary,
+    // 轴label
+    colorAxisLabel: colorTextPlaceholder,
     // label颜色
-    colorLabel: light ? colorGray90 : colorGray5,
-    // label禁用颜色（和文本禁用色保持一致）
-    colorLabelDisabled: light ? codeToRGB(colorGray90, 0.3) : codeToRGB(colorGray10, 0.3), // 确定
-    // 虚线的颜色
-    colorDash: light ? colorGray0 : colorGray90,
-    // 背景透明
-    colorBgTransparent: colorTransparent,
-    // 无数据占位背景
-    colorBgEmpty: light ? colorGray10 : codeToRGB(colorGray10, 0.1), // 确定
-    // labelLine颜色
-    colorLabelLine: light ? colorGray90 : colorGray5, // 确定
-    // 线透明
-    colorLineTransparent: colorTransparent,
-    // tip阴影垂直偏移
-    shadowOffsetY: space2x,
+    colorLabel: colorTextPrimary,
+    // 进度图专用name名称
+    colorLabelSecondary: colorTextPrimary,
+    // label禁用颜色
+    colorLabelDisabled: colorTextDisabled,
+    // 图标色
+    colorIcon: colorIconPrimary,
+    // 图标失效色
+    colorIconInactive: colorIconDisabled,
+    // 坐标轴线颜色
+    colorAxisLine: colorLine,
+    // 刻度线颜色
+    colorAxisTickLine: colorLine,
+    // 分隔线颜色
+    colorAxisSplitLine: colorLineSecondary,
+    // 用于极坐标的径向轴和雷达坐标的分隔线颜色，和坐标轴线颜色保持一致，特殊处理专用
+    colorAxisSplitLineSecondary: colorLine,
+    // 坐标轴指示器悬浮线
+    colorAxisPointerLine: colorLineSeparator,
+    // 分隔线
+    colorSeparatorLine: colorLineSeparator,
+    // lableline
+    colorLabelLine: colorLineSeparator,
+    // 无色
+    colorNone: colorFillNone,
+    //  占位色
+    colorPlaceholder: colorBgPlaceholder,
+    // 遮盖色
+    colorMask: colorBgMask,
+    // zoom背景色
+    colorZoomBg: colorBgHover,
+    // zoom border颜色
+    colorZoomBorder: colorBgHover,
+    // zoom 数据区域 border
+    colorZoomDataAreaBorder: colorBorder,
+    // zoom 数据区域填充
+    colorZoomDataAreaFill: colorFill,
+    // zoom 选中区域填充
+    colorZoomFill: colorFillSelect,
+    // zoom 选中区域数据border
+    colorZoomSelectDataAreaBorder: colorBorderSelect,
+    // zoom 选中区域数据填充
+    colorZoomSelectDataAreaFill: colorFillSelectSecondary,
+    // zoom 手柄颜色
+    colorZoomHandle: colorFillHandle,
+    // zoom 手柄border
+    colorZoomHandleBorder: colorBgHandle,
+    // hover阴影
+    colorShadowHover: colorFillHover,
+    // tip阴影
+    colorShadowContainer: colorShadowPrimary,
+    // 手柄阴影
+    colorShadowHandle: colorShadowSecondary,
+    // symbol hover填充
+    symbolFillHover: colorBgMask,
+    // ---------------------------------------------------阴影-------------------------------------------------
+    // tip阴影offsetY
+    shadowOffsetYContainer: shadowOffsetYPrimary,
+    // 手柄阴影offsetY
+    shadowOffsetYHandle: shadowOffsetYSecondary,
     // tip阴影模糊
-    shadowBlur: space6x,
+    shadowBlurContainer: shadowBlurPrimary,
+    // 手柄阴影模糊
+    shadowBlurHandle: shadowBlurSecondary,
+    // ------------------------------------------------------------------字号---------------------------------------------------
     // 主文本字号
     textFontSize: fontSizeMd, // 确定
     // 次级文本字号
@@ -130,6 +159,9 @@ function getAliasToken(globalToken, light = true) {
     titleFontSize: fontSize4xl,
     // 副标题文本字号
     subtitleFontSize: fontSizeLg,
+    // label字号
+    labelFontSize: fontSizeBase,
+    // ----------------------------------------------线宽---------------------------------------------------------
     // 坐标轴线宽 2
     axisLineWidth: border2x, // 确定
     // 用于极坐标系和雷达坐标系
@@ -138,64 +170,34 @@ function getAliasToken(globalToken, light = true) {
     axisTickLineWidth: border2x, // 确定
     // 分隔线线宽 1
     axisSplitLineWidth: borderBase, // 确定
-    // 极坐标系分隔线类型
-    axisSplitLineTypeSecondary: lineTypeSolid,
     // 坐标轴指示器的标线线宽 1
     axisPointerLineWidth: borderBase,
+    // 常规线宽
+    lineWidth: border2x,
+    // 二级线宽
+    lineWidthSecondary: borderBase,
+    // 无线宽
+    lineWidthNone: borderNone,
+    // -------------------------------------------------------------------线型-------------------------------------------------------------------
     // 坐标轴类型
     axisLineType: lineTypeSolid,
     // 刻度线类型
     axisTickLineType: lineTypeSolid,
-    // 坐标轴名称间距
-    axisNameSpace: space2x,
     // 直角坐标系分隔线类型
     axisSplitLineType: lineTypeSolid,
+    // 极坐标系分隔线类型
+    axisSplitLineTypeSecondary: lineTypeSolid,
     // 坐标轴指示器标线类型
     axisPointerLineType: lineTypeSolid,
+    // ---------------------------------------------------------------------间距-------------------------------------------------------------------------------
+    // 坐标轴名称间距
+    axisNameSpace: space2x,
     // 坐标轴文本间距
     axisLabelSpace: spaceBase,
-    // 标识线高亮宽度
-    markLineEmphasisWidth: borderBase,
-    //  border 0
-    borderWidthNone: borderNone,
     // 标题文本间距
     titleSpace: space2x,
-    // 标识线宽度
-    markLineWidth: borderBase,
     // 容器的间距
     containerGap: spaceBase,
-    // 容器的圆角
-    containerBoderRadius: borderRadiusBase,
-    // 图元
-    symbolSize: size3x,
-    // 图元 线形图用
-    symbolSizeSM: size2x,
-    // 图元的边框0
-    symbolBorderWidthNone: borderNone,
-    // 图元的边框
-    symbolBorderWidth: border2x,
-    // 柱条的宽度
-    barWidth: size2x,
-    // 堆叠进度图宽度 20
-    barWidthLG: size5x,
-    // label字号
-    labelFontSize: fontSizeBase,
-    // labelLine的长度
-    labelLineLength: size6x,
-    // 边框 细
-    borderWidth: borderBase,
-    // 边框
-    borderWidthLG: border2x,
-    // 圆角 0
-    borderRadiusNone,
-    // 圆角 小
-    borderRadius: borderRadiusBase,
-    lineWidth: border2x,
-    lineWidthNone: borderNone,
-    // 图例单元尺寸
-    legendItemSize: size05x,
-    // 图例圆形单元尺寸
-    legendCircleItemSize: size3x,
     // 图例的间距
     legendSpace: space8x,
     // 无padding
@@ -203,6 +205,41 @@ function getAliasToken(globalToken, light = true) {
     paddingSM: spaceBase,
     padding: space2x,
     paddingLG: space4x,
+    // -----------------------------------------------------------------边框------------------------------------------------------------------------------
+    // zoom数据区域边框
+    zoomDataAreaBorderWidth: borderBase,
+    // 边框 细
+    borderWidth: borderBase,
+    // 边框
+    borderWidthLG: border2x,
+    //  border 0
+    borderWidthNone: borderNone,
+    // 图元的边框0
+    symbolBorderWidthNone: borderNone,
+    // 图元的边框
+    symbolBorderWidth: border2x,
+    // -------------------------------------------------------------size----------------------------------------------------------------------------------------
+    // 图元
+    symbolSize: size3x,
+    // 图元 线形图用
+    symbolSizeSM: size2x,
+    // 柱条的宽度
+    barWidth: size2x,
+    // 堆叠进度图宽度 20
+    barWidthLG: size5x,
+    // 图例单元尺寸
+    legendItemSize: size05x,
+    // 图例圆形单元尺寸
+    legendCircleItemSize: size3x,
+    // labelLine的长度
+    labelLineLength: size6x,
+    // ------------------------------------------------圆角---------------------------------------------------
+    // 容器的圆角
+    containerBoderRadius: borderRadiusBase,
+    // 圆角 0
+    borderRadiusNone,
+    // 圆角 小
+    borderRadius: borderRadiusBase,
   };
 }
 

--- a/src/feature/token/theme/ict/getSceneToken.js
+++ b/src/feature/token/theme/ict/getSceneToken.js
@@ -1,0 +1,72 @@
+import { codeToRGB } from '../../../../util/color';
+function getSceneToken(globalToken, light = true) {
+    const {
+        colorGray0,
+        colorGray5,
+        colorGray10,
+        colorGray20,
+        colorGray50,
+        colorGray60,
+        colorGray70,
+        colorGray80,
+        colorGray90,
+        colorGray100,
+        colorTransparent,
+        colorBoard,
+        space2x,
+        space3x,
+        space6x,
+        spaceNone,
+    } = globalToken;
+
+    return {
+        // 用于实现一些遮盖场景
+        colorBgMask: light ? colorGray0 : colorGray90,
+        // 初级底色 (卡片)
+        colorBgPrimary: light ? colorGray0 : colorGray90,
+        // 次级背景色 (tip)
+        colorBgSecondary: light ? colorGray0 : colorGray70,
+        // 占位背景色
+        colorBgPlaceholder: light ? colorGray10 : codeToRGB(colorGray10, 0.1),
+        // datazoom背景
+        colorBgHover: light ? colorGray5 : colorGray80,
+        // datazoom  handle border
+        colorBgHandle: light ? colorGray0 : colorGray70,
+        // 主要文本色
+        colorTextPrimary: light ? colorGray90 : colorGray5,
+        // 次要文本色
+        colorTextSecondary: light ? colorGray60 : colorGray20,
+        // 占位文本色
+        colorTextPlaceholder: light ? colorGray60 : colorGray20,
+        // 禁用文本色
+        colorTextDisabled: light ? codeToRGB(colorGray90, 0.3) : codeToRGB(colorGray10, 0.3),
+        // 图标色
+        colorIconPrimary: light ? colorGray90 : colorGray10,
+        // 图标禁用色
+        colorIconDisabled: light ? codeToRGB(colorGray90, 0.3) : codeToRGB(colorGray10, 0.3),
+        colorLine: light ? colorGray10 : codeToRGB(colorGray10, 0.1),
+        colorLineSecondary: light ? codeToRGB(colorGray90, 0.1) : codeToRGB(colorGray10, 0.1),
+        colorLineSeparator: light ? colorGray20 : colorGray50,
+        colorFillNone: colorTransparent,
+        // datzoom 未选中数据  fill
+        colorFill: light ? colorGray20 : colorGray70,
+        // datzoom  选中区域 fill
+        colorFillSelect: codeToRGB(colorBoard.blue.colorBlue50, 0.1),
+        // datzoom  选中数据 fill
+        colorFillSelectSecondary: light ? codeToRGB(colorBoard.blue.colorBlue30, 0.2) : codeToRGB(colorBoard.blue.colorBlue70, 0.3),
+        // hover阴影
+        colorFillHover: light ? codeToRGB(colorGray90, 0.05) : codeToRGB(colorGray10, 0.08),
+        // datzoom handle 填充
+        colorFillHandle: light ? colorGray90 : colorGray0,
+        colorBorder: light ? colorGray20 : colorGray70,
+        colorBorderSelect: light ? codeToRGB(colorBoard.blue.colorBlue30, 0.2) : codeToRGB(colorBoard.blue.colorBlue70, 0.3),
+        colorShadowPrimary: light ? codeToRGB(colorGray100, 0.16) : codeToRGB(colorGray100, 0.5),
+        colorShadowSecondary: light ? codeToRGB(colorGray100, 0.04) : codeToRGB(colorGray100, 0.24),
+        shadowOffsetYPrimary: space2x,
+        shadowOffsetYSecondary: spaceNone,
+        shadowBlurPrimary: space6x,
+        shadowBlurSecondary: space3x,
+    }
+}
+
+export default getSceneToken

--- a/src/option/config/datazoom/base.js
+++ b/src/option/config/datazoom/base.js
@@ -10,12 +10,8 @@
  *
  */
 import Theme from '../../../feature/token';
-import { codeToRGB } from '../../../util/color';
 
-function getBaseOption(isDark) {
-  // 暂时固定颜色
-  const selectedDataBackgroundLineColor = isDark ? '#1B3F86' : '#8CA3FA'
-  const selectedDataBackgroundAreaColor = isDark ? '#1B3F86' : '#8CA3FA'
+function getBaseOption() {
   return {
     end: 100,
     start: 0,
@@ -29,16 +25,16 @@ function getBaseOption(isDark) {
     borderColor: Theme.config.dataZoomBorderColor, // 边框
     borderRadius: 0,
     backgroundColor: Theme.config.dataZoomBackgroundColor, // 背景颜色
-    fillerColor: codeToRGB(Theme.config.colorState.colorInfo, 0.1), // 选中范围填充颜色
+    fillerColor: Theme.config.dataZoomFillColor, // 选中范围填充颜色
     handleSize: '68%', // 控制手柄的尺寸
     handleIcon: 'path://M0 0 L5 0 L5 12 L0 12 L0 0 Z', // 手柄形状
     showDetail: false,
     handleStyle: {
       color: Theme.config.dataZoomHandleColor,  // 手柄颜色
-      shadowBlur: 12, // 阴影模糊大小
+      shadowBlur: Theme.config.dataZoomHandleShadowBlur,
       shadowColor: Theme.config.dataZoomHandleShadowColor,
       shadowOffsetX: 0, // 阴影偏移x轴多少
-      shadowOffsetY: 0, // 阴影偏移y轴多少
+      shadowOffsetY: Theme.config.dataZoomHandleShadowOffsetY, // 阴影偏移y轴多少
       opacity: 1, // 透明度
       borderColor: Theme.config.dataZoomHandleBorderColor, // 手柄边框颜色
       borderWidth: 6, // 手柄边框宽度
@@ -46,23 +42,25 @@ function getBaseOption(isDark) {
     },
     dataBackground: {
       lineStyle: {
-        color: Theme.config.dataBackgroundLineColor, // 线条颜色
+        width: Theme.config.dataZoomDataBackgroundLineWidth,
+        color: Theme.config.dataZoomDataBackgroundLineColor, // 线条颜色
         join: 'round',
         cap: 'round',
       },
       areaStyle: {
         opacity: 1, // 阴影的透明度
-        color: Theme.config.dataBackgroundAreaColor, // 填充的颜色
+        color: Theme.config.dataZoomDataBackgroundAreaColor, // 填充的颜色
       },
     },
     selectedDataBackground: {
       // 选中部分样式
       lineStyle: {
-        color: selectedDataBackgroundLineColor, // 线条颜色
+        width: Theme.config.dataZoomDataBackgroundLineWidth,
+        color: Theme.config.dataZoomSelectedDataLineColor, // 线条颜色
       },
       areaStyle: {
         opacity: 1, // 阴影的透明度
-        color: selectedDataBackgroundAreaColor, // 填充的颜色
+        color: Theme.config.dataZoomSelectedDataAreaColor, // 填充的颜色
       },
     },
     moveHandleSize: '0', // 移动手柄的尺寸高度
@@ -75,8 +73,7 @@ function getBaseOption(isDark) {
   }
 }
 
-function getMiniBaseOption(isDark) {
-  const fillerColor = isDark ? codeToRGB(Theme.config.colorState.colorInfo, 0.3) : codeToRGB(Theme.config.colorState.colorInfo, 0.2)
+function getMiniBaseOption() {
   return {
     end: 100,
     start: 0,
@@ -90,7 +87,7 @@ function getMiniBaseOption(isDark) {
     borderColor: Theme.config.dataZoomBorderColorMini, // 边框
     borderRadius: 0,
     backgroundColor: Theme.config.dataZoomBackgroundColor, // 背景颜色
-    fillerColor, // 选中范围填充颜色
+    fillerColor: Theme.config.dataZoomFillColor, // 选中范围填充颜色
     handleSize: '100%', // 控制手柄的尺寸
     handleIcon: 'path://M0 0 L8 0 L8 12 L0 12 L0 0 Z', // 手柄形状
     showDetail: false,
@@ -98,10 +95,10 @@ function getMiniBaseOption(isDark) {
     showDataShadow: false,
     handleStyle: {
       color: Theme.config.dataZoomHandleColor,  // 手柄颜色
-      shadowBlur: 6, // 阴影模糊大小
+      shadowBlur: Theme.config.dataZoomHandleShadowBlur, // 阴影模糊大小
       shadowColor: Theme.config.dataZoomHandleShadowColorMini,
-      shadowOffsetX: 1, // 阴影偏移x轴多少
-      shadowOffsetY: 0, // 阴影偏移y轴多少
+      shadowOffsetX: 0, // 阴影偏移x轴多少
+      shadowOffsetY: Theme.config.dataZoomHandleShadowOffsetY, // 阴影偏移y轴多少
       opacity: 1, // 透明度
       borderColor: Theme.config.dataZoomHandleBorderColor, // 手柄边框颜色
       borderWidth: 3, // 手柄边框宽度
@@ -118,9 +115,7 @@ function getMiniBaseOption(isDark) {
 }
 function base(iDataZoom) {
   const { mini } = iDataZoom
-  const theme = Theme.themeName
-  const isDark = theme.includes('dark')
-  return mini ? getMiniBaseOption(isDark) : getBaseOption(isDark)
+  return mini ? getMiniBaseOption() : getBaseOption()
 }
 
 export default base;

--- a/src/option/config/mark/index.js
+++ b/src/option/config/mark/index.js
@@ -13,14 +13,8 @@
 import Theme from '../../../feature/token';
 import merge from '../../../util/merge';
 
-function getThresholdLabelBgColor() {
-  const redGroup = Theme.config.colorBoard.red
-  return Object.values(redGroup)[0];
-}
-
 function getThresholdMarkLineLabel() {
   const { colorError } = Theme.config.colorState
-  const bg = getThresholdLabelBgColor()
   return {
     label: {
       color: colorError,
@@ -70,7 +64,7 @@ function getMarkPointDefault() {
     symbol: 'path://M50 0 L0 50 L100 50 Z',
     symbolSize: [10, 6],
     label: {
-      color: Theme.config.markPointLabelColor,
+      show: false,
     },
     data: [],
   };


### PR DESCRIPTION
 add cloud-dark theme token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a refreshed visual theme with updated color palettes for charts and UI components that adapt seamlessly to dark and light modes.
  - Added new color definitions and properties for various chart components, enhancing the visual representation and customization options.
  - Implemented new functions to manage scene-related color tokens for improved theming flexibility.

- **Style**
  - Enhanced the appearance of chart elements—such as labels, tooltips, and borders—and refined card styling to boost readability and consistency.

- **Refactor**
  - Streamlined theming configurations and color token management to ensure robust customization and maintainability across the interface.
  - Removed redundant functions and simplified existing function signatures for improved clarity and performance.
  - Centralized color management through the `Theme.config` object for consistent styling across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->