### PR TITLE
fix(token): modify the token to solve the bug where transparent cannot parse correctly

### DIFF
--- a/src/components/LineChart/AreaChart/bottomArea.js
+++ b/src/components/LineChart/AreaChart/bottomArea.js
@@ -105,11 +105,11 @@ function pureBottomArea(itemx, percentx, bottomColorx) {
         colorStops: [
           {
             offset: 0,
-            color: 'rgba(255,255,255,0.001)', //解决svg渲染方式下面积图低阈值黑色背景的问题
+            color: chartToken.colorAreaTP, //解决svg渲染方式下面积图低阈值黑色背景的问题
           },
           {
             offset: 1 - percentx - 0.00001,
-            color: 'rgba(255,255,255,0.001)',
+            color: chartToken.colorAreaTP,
           },
           {
             offset: 1 - percentx,

--- a/src/feature/token/color/cloud/board-dark.js
+++ b/src/feature/token/color/cloud/board-dark.js
@@ -236,7 +236,7 @@ const gray = {
 };
 
 const transparent = {
-  colorTransparent: 'transparent',
+  colorTransparent: 'rgba(255,255,255,0)',
 };
 
 const board = {

--- a/src/feature/token/color/cloud/board.js
+++ b/src/feature/token/color/cloud/board.js
@@ -251,7 +251,7 @@ const gray = {
 };
 
 const transparent = {
-  colorTransparent: 'transparent',
+  colorTransparent: 'rgba(255,255,255,0)',
 };
 
 const board = {

--- a/src/feature/token/color/hdesign/board.js
+++ b/src/feature/token/color/hdesign/board.js
@@ -181,7 +181,7 @@ const gray = {
 };
 
 const transparent = {
-  colorTransparent: 'transparent',
+  colorTransparent: 'rgba(255,255,255,0)',
 };
 
 const board = {

--- a/src/feature/token/color/ict/board.js
+++ b/src/feature/token/color/ict/board.js
@@ -168,11 +168,11 @@ const gray = {
 };
 
 const transparent = {
-  colorTransparent: 'transparent',
+  colorTransparent: 'rgba(255,255,255,0)',
 };
 
 const board = {
-	blue,
+  blue,
   pink,
   gray,
   green,

--- a/src/feature/token/theme/hdesign/getSceneToken.js
+++ b/src/feature/token/theme/hdesign/getSceneToken.js
@@ -57,8 +57,8 @@ function getSceneToken(globalToken, light = true) {
         colorFillSelect: codeToRGB(colorBoard.blue.colorBlue50, 0.1),
         // datzoom  选中数据 fill
         colorFillSelectSecondary: light ? codeToRGB(colorBoard.blue.colorBlue30, 0.2) : codeToRGB(colorBoard.blue.colorBlue70, 0.3),
-        // hover阴影
-        colorFillHover: light ? codeToRGB(colorGray90, 0.05) : codeToRGB(colorGray5, 0.2),
+        // hover阴影(黑色主题字典中的值是codeToRGB(colorGray5, 0.2)太亮了,待后续沟通)
+        colorFillHover: light ? codeToRGB(colorGray90, 0.05) : codeToRGB(colorGray5, 0.1),
         // datzoom handle 填充
         colorFillHandle: light ? colorGray90 : colorGray10,
         colorBorder: light ? colorGray10 : colorGray70,


### PR DESCRIPTION
fix(token): modify the token field colorTransparent to rgba (255,255,255,0) to solve the bug where Transparent cannot parse correctly in some scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the transparent color definitions in board themes to use an RGBA value (white with zero opacity) for more precise rendering.

- **Refactor**
  - Standardized color property syntax for improved consistency in board themes.

- **New Features**
  - Enhanced visual representation in charts by linking area color gradients to updated color definitions.
  
- **Bug Fixes**
  - Adjusted hover color opacity in dark themes for improved visual clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->