### PR TITLE
fix(PieChart): fix for keeping decimals when the type of label is per…

### DIFF
--- a/src/components/PieChart/handleLabel.js
+++ b/src/components/PieChart/handleLabel.js
@@ -51,8 +51,14 @@ function hasLabelFormatterFun(labelFormatterType, seriesUnit, sum) {
         if (params.value === 0) {
           return '0(0 %)';
         } else {
-          const percent = ((params.value * 100) / sum).toFixed(2);
-          return `${percent} %`;
+          const percent = params.value / sum * 100;
+          // 检查是否有小数
+          if (Number.isInteger(percent)) {
+            return `${percent} %`
+          } else {
+            return `${percent.toFixed(2)} %`
+          }
+          ;
         }
       };
       break;


### PR DESCRIPTION
…cent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced chart label formatting so that whole number percentages appear without decimals and fractional percentages are shown with two-decimal precision, offering a cleaner and more accurate visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->