### PR TITLE
feat(JadeJueChart): add automatic centring of title

### DIFF
--- a/public/example_data/JadeJueChart.json
+++ b/public/example_data/JadeJueChart.json
@@ -15,11 +15,6 @@
           "imagePath": "./image/theme/light/JadeJueChart/JadeJueChart-5.png"
         },
         {
-          "name": "进度玉玦图",
-          "routePath": "JadeJueChart-11",
-          "imagePath": "./image/theme/light/JadeJueChart/JadeJueChart-11.png"
-        },
-        {
           "name": "数据为0时最小占比",
           "routePath": "JadeJueChart-10",
           "imagePath": "./image/theme/light/JadeJueChart/JadeJueChart-10.png"

--- a/src/components/JadeJueChart/index.js
+++ b/src/components/JadeJueChart/index.js
@@ -17,6 +17,7 @@ import { handleLabelFormatter } from './labelFormatter';
 import PolarCoordSys from '../../option/PolarSys';
 import { setStartAngle, setbarWidth, handleLegendData, bindLegendEvent } from './handleOption';
 import { CHART_TYPE } from '../../util/constants';
+import handleCenterTitle from '../../option/config/polarTitle/handleCenterTitle';
 
 class JadeJueChart {
 
@@ -54,6 +55,10 @@ class JadeJueChart {
     handleLegendData(iChartOption, this.baseOption, this.chartType);
     // 绑定图例点击事件，更新背景柱条对应series的数据
     bindLegendEvent(this, chartInstance);
+    if (this.baseOption?.title?.text || this.baseOption?.title?.subtext) {
+      let position = iChartOption.position || this.baseOption.polar;
+      handleCenterTitle(position, chartInstance, this.baseOption, iChartOption);
+    }
   }
 
   getOption() {
@@ -64,6 +69,10 @@ class JadeJueChart {
 
   resize(callback){
     setbarWidth(this.iChartOption, this.baseOption, this.chartInstance, this.chartType);
+    if (this.baseOption?.title?.text || this.baseOption?.title?.subtext) {
+      let position = this.iChartOption.position || this.baseOption.polar;
+      handleCenterTitle(position, this.chartInstance, this.baseOption, this.iChartOption);
+    }
     callback(this.baseOption)
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced chart visualization with improved title centering. The chart now automatically adjusts title alignment during updates and resizing based on its configuration, ensuring a more balanced and visually appealing display.
  
- **Bug Fixes**
  - Removed the "进度玉玦图" (Progress Jade Jue Chart) entry from the chart configuration, streamlining the available options in the Basic Form section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->