### PR TITLE
fix(GaugeChart): add default theme colors for dashboard units

### DIFF
--- a/src/components/GaugeChart/handleSeries.js
+++ b/src/components/GaugeChart/handleSeries.js
@@ -153,6 +153,9 @@ function handleDetail(seriesUnit, text, data) {
       color: chartToken.descRichColor,
       padding: [24, 0, 0, 0],
     },
+    unit: {
+      color: chartToken.detailRichColor
+    }
   };
   if (text?.formatterStyle) {
     merge(seriesUnit.detail.rich, text.formatterStyle)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced gauge chart detail display by allowing the unit text to have a distinct color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->