### PR TITLE
feat(Tooltip): add HideEmpty property to ensure that the item is not displayed when the data does not exist

### DIFF
--- a/src/components/BarChart/handleOptipn.js
+++ b/src/components/BarChart/handleOptipn.js
@@ -56,10 +56,11 @@ function setAbsoluteYaxisLabel(baseOption) {
   });
 }
 
-function setTipFormatter(params) {
+function setTipFormatter(params, hideEmpty) {
   const config = {
     title: '',
-    children: []
+    children: [],
+    hideEmpty
   }
   params.forEach((item, index) => {
     if (index === 0) {
@@ -85,7 +86,9 @@ export function setDoubleSides(baseOption, iChartOption) {
   if (type && type === 'double-sides') {
     setAbsoluteYaxisLabel(baseOption)
     if (!baseOption.tooltip.formatter) {
-      baseOption.tooltip.formatter = setTipFormatter
+      baseOption.tooltip.formatter = (echartsParams, ticket, callback)=>{
+        setTipFormatter(echartsParams, baseOption.tooltip?.hideEmpty)
+      } 
     }
   }
 }

--- a/src/components/BarChart/handleSeries.js
+++ b/src/components/BarChart/handleSeries.js
@@ -693,7 +693,8 @@ export function setLimitFormatter(baseOption, iChartOption, seriesData) {
     }
     const config = {
       title: '',
-      children: []
+      children: [],
+      hideEmpty: baseOption.tooltip?.hideEmpty
     }
     newParams.forEach((item, index) => {
       let value = item.value || seriesData[item.seriesName][item.dataIndex];

--- a/src/components/LineChart/handleOptipn.js
+++ b/src/components/LineChart/handleOptipn.js
@@ -97,10 +97,11 @@ export function discrete(iChartOption, baseOption) {
   }
 }
 
-function defaultFormatter(params, color, iChartOpt) {
+function defaultFormatter(params, color, iChartOpt, hideEmpty) {
   const config = {
     title: '',
-    children: []
+    children: [],
+    hideEmpty
   }
   params.forEach((item, index) => {
     let value = item.value;
@@ -150,6 +151,6 @@ export function setTooltip(baseOpt, iChartOpt, legendData) {
       params = echartsParams.slice(0, lineNumber)
     }
     const initParams = coverObjDataToInit(params)
-    return formatter ? formatter(initParams, ticket, callback) : defaultFormatter(initParams, color, iChartOpt)
+    return formatter ? formatter(initParams, ticket, callback) : defaultFormatter(initParams, color, iChartOpt, baseOpt.tooltip?.hideEmpty)
   }
 }

--- a/src/components/ProcessChart/handleOption.js
+++ b/src/components/ProcessChart/handleOption.js
@@ -173,7 +173,8 @@ function handleStackTipFormatter(baseOpt, iChartOpt) {
     if (name === 'null') return
     const config = {
       title: name,
-      children: []
+      children: [],
+      hideEmpty: baseOpt.tooltip?.hideEmpty
     }
     params.forEach((param, index) => {
       if (index > 1) {

--- a/src/option/config/tooltip/formatter.js
+++ b/src/option/config/tooltip/formatter.js
@@ -46,15 +46,17 @@ function getDataHtmlStr(dataConfig) {
 
 function getTooltipContentHtmlStr(tipConfig) {
     const { tooltipItemGap, tooltipTitleColor } = Token.config
-    const { title, titleColor = tooltipTitleColor, children } = tipConfig
+    const { title, titleColor = tooltipTitleColor, children, hideEmpty } = tipConfig
     let content = ''
     if (validateName(title)) {
         content = `<div style="color:${titleColor}">${defendXSS(title)}</div>`;
     }
     if (children && children.length !== 0) {
-        children.forEach(item => {
+        for (let index = 0; index < children.length; index++) {
+            const item = children[index];
+            if( hideEmpty && (item.value === null || item.value === undefined || item.value === '')) continue;
             content += getDataHtmlStr(item)
-        })
+        }
     }
     const htmlString = `<div style="display:flex;flex-direction:column;gap:${tooltipItemGap}px;">${content}</div>`
     return htmlString;


### PR DESCRIPTION
…t exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for hiding empty values in chart tooltips across Bar, Line, and Process charts. Tooltips now offer an option to exclude entries with empty or null values for a cleaner display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->