### PR TITLE
fix(BulletChart): modify the default color of the bullet map threshold line to match the theme color

### DIFF
--- a/src/components/BulletChart/handleSeries.js
+++ b/src/components/BulletChart/handleSeries.js
@@ -109,7 +109,7 @@ export function handleSeries(baseOpt, iChartOpt, legendData ,seriesData) {
         symbolOffset: iChartOpt.markLine.symbolOffset ? iChartOpt.markLine.symbolOffset : [0, 0],
         z: 20,
         data: markLineData,
-        color: iChartOpt.markLine.color ? iChartOpt.markLine.color : handleSetColor(iChartOpt.markLine,1),
+        color: iChartOpt.markLine.color ? iChartOpt.markLine.color : baseOpt.color[0],
         emphasis: {
             scale: false
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the default color for mark line scatter series in bullet charts, resulting in a more consistent appearance when no custom color is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->