### PR TITLE
fix(BullleChart): modifiy the default width of the threshold line

### DIFF
--- a/src/components/BulletChart/handleSeries.js
+++ b/src/components/BulletChart/handleSeries.js
@@ -105,7 +105,7 @@ export function handleSeries(baseOpt, iChartOpt, legendData ,seriesData) {
         type: 'scatter',
         symbol: 'rect',
         silent: true,
-        symbolSize: iChartOpt.markLine.symbolSize ? iChartOpt.markLine.symbolSize : [32, 2],
+        symbolSize: iChartOpt.markLine.symbolSize ? iChartOpt.markLine.symbolSize : [backgroundWidth, 2],
         symbolOffset: iChartOpt.markLine.symbolOffset ? iChartOpt.markLine.symbolOffset : [0, 0],
         z: 20,
         data: markLineData,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the default width of mark line symbols in bullet charts to dynamically match the configured background width, ensuring better visual alignment and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->