### PR TITLE
fix(Legend): not take effect when position is set to 0

### DIFF
--- a/src/option/config/legend/position.js
+++ b/src/option/config/legend/position.js
@@ -10,10 +10,11 @@
  *
  */
 function position(legend, selfLegend){
-    legend.top = selfLegend.position.top || 'auto';
-    legend.left = selfLegend.position.left || 'auto';
-    legend.right = selfLegend.position.right || 'auto';
-    legend.bottom = selfLegend.position.bottom || 'auto';
+    const { position } = selfLegend;
+    legend.top = position?.top !== undefined ? position.top : 'auto';
+    legend.left = position?.left !== undefined ? position.left : 'auto';
+    legend.right = position?.right !== undefined ? position.right : 'auto';
+    legend.bottom = position?.bottom !== undefined ? position.bottom : 'auto';
 }
 
 export default position;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of legend position values to ensure valid values like 0 are correctly applied, preventing unintended defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->