### PR TITLE
fix(PieChart): slove the error of titile.text is not string

### DIFF
--- a/public/option/PieChart/PieChart-13.js
+++ b/public/option/PieChart/PieChart-13.js
@@ -1,7 +1,7 @@
 const option = {
     theme: 'hdesign-light',
     title: {
-        text: '{a|225}{b|GB} ',
+        text: '{a|225}{b|GB}',
         subtext: '总数',
         itemGap:2,
         textStyle: {

--- a/src/option/config/polarTitle/handleCenterTitle.js
+++ b/src/option/config/polarTitle/handleCenterTitle.js
@@ -14,8 +14,12 @@ import { percentToDecimal } from '../../../util/math';
 
 function updateTitle(position, chartInstance, baseOption, iChartOption) {
   // 获取圆环主副文本
-  baseOption.title.text = removeOuterSpaces(baseOption.title.text);
-  baseOption.title.subtext = removeOuterSpaces(baseOption.title.subtext);
+  if (typeof baseOption.title?.text === 'string') {
+    baseOption.title.text = removeOuterSpaces(baseOption.title.text);
+  }
+  if (typeof baseOption.title?.subtext === 'string') {
+    baseOption.title.subtext = removeOuterSpaces(baseOption.title.subtext);
+  }
   const textContent = baseOption.title.text;
   const subtextContent = baseOption.title.subtext;
   const textStyle = baseOption.title.textStyle;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a minor formatting issue in chart titles by removing an unintended trailing space.
	- Improved title handling to prevent errors when title or subtitle text is missing or not a string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->