### PR TITLE
fix(core): fix a situation without echart _dom, resize causes getWidth error

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -149,8 +149,8 @@ export default class CoreChart extends BaseChart {
   // 图表宽高自适应
   setResize() {
     this.mediaScreenObserver && this.mediaScreenObserver.observe();
-    this.echartsIns && this.echartsIns.resize && this.echartsIns.resize({ width: 'auto' });
-    this.ichartsIns && this.ichartsIns.resize && this.ichartsIns.resize((resizedOption) => {
+    this.echartsIns && this.echartsIns._dom && this.echartsIns.resize && this.echartsIns.resize({ width: 'auto' });
+    this.echartsIns && this.echartsIns._dom && this.ichartsIns && this.ichartsIns.resize && this.ichartsIns.resize((resizedOption) => {
       this.setOption(resizedOption);
     });
   }


### PR DESCRIPTION
…th error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chart resizing behavior to prevent errors when the chart's underlying DOM element is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->