### PR TITLE
fix(LineChart): tooltip exception while repairing discrete data

### DIFF
--- a/src/components/LineChart/handleOptipn.js
+++ b/src/components/LineChart/handleOptipn.js
@@ -103,26 +103,32 @@ function defaultFormatter(params, color, iChartOpt, hideEmpty) {
     children: [],
     hideEmpty
   }
+  let seriesNames = [];
   params.forEach((item, index) => {
     let value = item.value;
     let name = item.seriesName;
-    if (isObject(value)){
-      iChartOpt.data.forEach(data=>{
-        if (data.product === value?.product) {
-          value = data[name];
-        }
-      })
+    if (iChartOpt.discrete && seriesNames.includes(name)) {
+      return;
+    }else{
+      seriesNames.push(name);
+      if (isObject(value)){
+        iChartOpt.data.forEach(data=>{
+          if (data.product === value?.product) {
+            value = data[name];
+          }
+        })
+      }
+      if (index === 0) {
+        config.title = item.name
+      }
+      const iconColor = validateName(value) ? item.color : getColor(color, item.seriesIndex)
+      const dataItem = {
+        name,
+        value,
+        iconColor,
+      }
+      config.children.push(dataItem)
     }
-    if (index === 0) {
-      config.title = item.name
-    }
-    const iconColor = validateName(value) ? item.color : getColor(color, item.seriesIndex)
-    const dataItem = {
-      name,
-      value,
-      iconColor,
-    }
-    config.children.push(dataItem)
   });
   return getTooltipContentHtmlStr(config)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where duplicate series names appeared in the tooltip when discrete mode is enabled in line charts. Tooltips now display each series name only once for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->