### PR TITLE
fix(LineChart): increase the type judgment of formatter function

### DIFF
--- a/src/components/LineChart/handleOptipn.js
+++ b/src/components/LineChart/handleOptipn.js
@@ -151,6 +151,6 @@ export function setTooltip(baseOpt, iChartOpt, legendData) {
       params = echartsParams.slice(0, lineNumber)
     }
     const initParams = coverObjDataToInit(params)
-    return formatter ? formatter(initParams, ticket, callback) : defaultFormatter(initParams, color, iChartOpt, baseOpt.tooltip?.hideEmpty)
+    return formatter && typeof formatter === 'function' ? formatter(initParams, ticket, callback) : defaultFormatter(initParams, color, iChartOpt, baseOpt.tooltip?.hideEmpty)
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip formatting in line charts by ensuring custom formatters are only called if they are valid functions, preventing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->