### PR TITLE
fix(Token): update the legend fontSize of cloud theme

### DIFF
--- a/src/feature/token/theme/cloud/getAliasToken.js
+++ b/src/feature/token/theme/cloud/getAliasToken.js
@@ -229,7 +229,7 @@ function getAliasToken(globalToken, sceneToken) {
     // 图例value字体大小
     legendTextValueFontSize: fontSizeMd,
     // 图例名称字体大小
-    legendTextNameFontSize: fontSizeMd,
+    legendTextNameFontSize: fontSizeBase,
     // 无padding
     paddingNone: spaceNone,
     paddingSM: spaceBase,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted legend label font size in the Cloud theme to use the base text size for improved visual consistency.
  * Users may notice slightly refined sizing of legend text across components that display legends, enhancing readability and alignment with overall typography.
  * No functional changes; this is a visual polish affecting presentation only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->