### PR TITLE
fix(Theme): add export color keys

### DIFF
--- a/src/feature/token/factory/getExportColors.js
+++ b/src/feature/token/factory/getExportColors.js
@@ -15,7 +15,8 @@ const EXPORT_COLORS_KEY = [
     'textPrimary',
     'textSecondary',
     'textPlaceholder',
-    'textDisabled'
+    'textDisabled',
+    'themeToken'
 ]
 
 function getExportColors(colorSet, sceneToken, themeToken) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a new exported color token for themes, allowing consumers to reference 'themeToken' in color exports and design configurations; ensures consistency and expands customization options. No breaking changes; existing tokens unchanged. The new token appears in export lists and can be used wherever color tokens are selectable or downloadable. Visible in UI and API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->