### PR TITLE
fix(AreaChart): areachart color gradient not working when markLine is an array

### DIFF
--- a/src/components/LineChart/index.js
+++ b/src/components/LineChart/index.js
@@ -23,7 +23,7 @@ import { handleData, onlyOnePoint, discrete, setTooltip } from './handleOptipn';
 import RectCoordSys, { xkey, xdata, ldata, ydata } from '../../option/RectSys';
 import { lttb } from '../../feature/performance/lttb';
 import { CHART_TYPE } from '../../util/constants';
-import { isArray } from '../../util/type';
+import { isArray, isObject } from '../../util/type';
 
 class LineChart {
 
@@ -103,9 +103,7 @@ class LineChart {
   updateOptionAgain(echartsIns) {
     const YAxiMax = this.getYAxisMaxValue(echartsIns, 0);
     const YAxiMin = this.getYAxisMinValue(echartsIns, 0);
-    if(isArray(this.iChartOption.markLine)){
-
-    }else{
+    if(isObject(this.iChartOption.markLine)){
       // 面积图上部红色阈值区域需要在二次计算中实现 -- 在原有Series上添加areaStyle
       topArea(this.baseOption, this.iChartOption, YAxiMin, YAxiMax);
       // 面积图下部红色阈值区域需要在二次计算中实现 -- 植入假的同名Series


### PR DESCRIPTION
…loration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - LineChart threshold shading behavior updated: the upper threshold area is rendered only when a single threshold object is configured. When thresholds are provided as an array or not set, no threshold area is shown. Lower (bottom) threshold shading has been removed to avoid unintended highlights. This improves visual consistency without changing the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->