### PR TITLE
fix(WordCloudChart): fix unable to set font range

### DIFF
--- a/src/components/WordCloudChart/index.js
+++ b/src/components/WordCloudChart/index.js
@@ -43,7 +43,7 @@ class WordCloudChart {
       width: iChartOption.width,
       height: iChartOption.height,
       gridSize: iChartOption.gridSize,
-      sizeRang: iChartOption.sizeRange,
+      sizeRange: iChartOption.sizeRange,
       rotationRange: iChartOption.rotationRange,
       rotationStep: iChartOption.rotationStep,
       shape: iChartOption.shape,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed word sizing in Word Cloud charts: the configured size range is now honored, preventing inconsistent or incorrect scaling. Users should see more accurate and predictable visualizations across datasets and themes. This change is internal and does not alter any public APIs or require configuration updates. Existing dashboards and reports will continue to work as before, with improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->