### PR TITLE
fix(Tooltip): correct display order when order is seriesDesc

### DIFF
--- a/src/components/BarChart/handleOptipn.js
+++ b/src/components/BarChart/handleOptipn.js
@@ -56,7 +56,7 @@ function setAbsoluteYaxisLabel(baseOption) {
   });
 }
 
-function setTipFormatter(params, hideEmpty) {
+function setTipFormatter(params, hideEmpty, tooltip) {
   const config = {
     title: '',
     children: [],
@@ -74,7 +74,7 @@ function setTipFormatter(params, hideEmpty) {
     }
     config.children.push(dataItem)
   });
-  return getTooltipContentHtmlStr(config);
+  return getTooltipContentHtmlStr(config, tooltip);
 }
 
 /**
@@ -87,7 +87,7 @@ export function setDoubleSides(baseOption, iChartOption) {
     setAbsoluteYaxisLabel(baseOption)
     if (!baseOption.tooltip.formatter) {
       baseOption.tooltip.formatter = (echartsParams, ticket, callback)=>{
-        setTipFormatter(echartsParams, baseOption.tooltip?.hideEmpty)
+        setTipFormatter(echartsParams, baseOption.tooltip?.hideEmpty, baseOption.tooltip)
       } 
     }
   }

--- a/src/components/BarChart/handleSeries.js
+++ b/src/components/BarChart/handleSeries.js
@@ -723,7 +723,7 @@ export function setLimitFormatter(baseOption, iChartOption, seriesData) {
       }
       config.children.push(dataItem)
     });
-    return getTooltipContentHtmlStr(config);
+    return getTooltipContentHtmlStr(config, baseOption.tooltip);
   };
 }
 

--- a/src/components/LineChart/handleOptipn.js
+++ b/src/components/LineChart/handleOptipn.js
@@ -97,7 +97,7 @@ export function discrete(iChartOption, baseOption) {
   }
 }
 
-function defaultFormatter(params, color, iChartOpt, hideEmpty) {
+function defaultFormatter(params, color, iChartOpt, hideEmpty, tooltip) {
   const config = {
     title: '',
     children: [],
@@ -130,7 +130,7 @@ function defaultFormatter(params, color, iChartOpt, hideEmpty) {
       config.children.push(dataItem)
     }
   });
-  return getTooltipContentHtmlStr(config)
+  return getTooltipContentHtmlStr(config, tooltip)
 }
 
 // 阈值场景将data中的数据转为obj，需要转换回来
@@ -157,6 +157,6 @@ export function setTooltip(baseOpt, iChartOpt, legendData) {
       params = echartsParams.slice(0, lineNumber)
     }
     const initParams = coverObjDataToInit(params)
-    return formatter && typeof formatter === 'function' ? formatter(initParams, ticket, callback) : defaultFormatter(initParams, color, iChartOpt, baseOpt.tooltip?.hideEmpty)
+    return formatter && typeof formatter === 'function' ? formatter(initParams, ticket, callback) : defaultFormatter(initParams, color, iChartOpt, baseOpt.tooltip?.hideEmpty, baseOpt.tooltip)
   }
 }

--- a/src/components/ProcessChart/handleOption.js
+++ b/src/components/ProcessChart/handleOption.js
@@ -188,7 +188,7 @@ function handleStackTipFormatter(baseOpt, iChartOpt) {
         config.children.push(dataItem)
       }
     });
-    return getTooltipContentHtmlStr(config)
+    return getTooltipContentHtmlStr(config, baseOpt.tooltip)
   };
 }
 

--- a/src/option/config/tooltip/formatter.js
+++ b/src/option/config/tooltip/formatter.js
@@ -48,12 +48,15 @@ function getDataHtmlStr(dataConfig) {
             </div>`;
 }
 
-function getTooltipContentHtmlStr(tipConfig) {
+function getTooltipContentHtmlStr(tipConfig, tooltip) {
     const { tooltipItemGap, tooltipTitleColor } = Token.config
-    const { title, titleColor = tooltipTitleColor, children, hideEmpty } = tipConfig
+    let { title, titleColor = tooltipTitleColor, children, hideEmpty } = tipConfig
     let content = ''
     if (validateName(title)) {
         content = `<div style="color:${titleColor}">${defendXSS(title)}</div>`;
+    }
+    if (tooltip?.order === 'seriesDesc') {
+        children = children.reverse();
     }
     if (children && children.length !== 0) {
         for (let index = 0; index < children.length; index++) {


### PR DESCRIPTION
…versed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tooltips now support configurable series order (e.g., descending) across Bar, Line, and Process charts.

- Bug Fixes
  - Tooltip formatting consistently respects “hide empty” values and chart-level tooltip settings.
  - Unified default tooltip behavior across chart types for more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->