### PR TITLE
fix(ExpandLegend): avoid simultaneous display of conflicting default legend items

### DIFF
--- a/public/quick_start/ExpandLegendAPI.md
+++ b/public/quick_start/ExpandLegendAPI.md
@@ -6,6 +6,10 @@
 
 ```javascript
 // 示例
+import HuiCharts from '{{VITE_BASECOPYRIGHTSPAT}}';
+// 引入样式
+import '{{VITE_BASECOPYRIGHTSPAT}}/feature/expandLegend/index.css'
+
 const chartIns = new HuiCharts();
 const chartType = "lineChart";
 const chartOption = {
@@ -33,6 +37,10 @@ chartIns.render();
 
 ```javascript
 // 示例
+import HuiCharts from '{{VITE_BASECOPYRIGHTSPAT}}';
+// 引入样式
+import '{{VITE_BASECOPYRIGHTSPAT}}/feature/expandLegend/index.css'
+
 const chartIns = new HuiCharts();
 const chartType = "lineChart";
 const chartOption = {
@@ -59,6 +67,10 @@ chartIns.render();
 
 ```javascript
 // 示例
+import HuiCharts from '{{VITE_BASECOPYRIGHTSPAT}}';
+// 引入样式
+import '{{VITE_BASECOPYRIGHTSPAT}}/feature/expandLegend/index.css'
+
 const chartIns = new HuiCharts();
 const chartType = "lineChart";
 const chartOption = {
@@ -87,6 +99,10 @@ chartIns.render();
 
 ```javascript
 // 示例
+import HuiCharts from '{{VITE_BASECOPYRIGHTSPAT}}';
+// 引入样式
+import '{{VITE_BASECOPYRIGHTSPAT}}/feature/expandLegend/index.css'
+
 const chartIns = new HuiCharts();
 const chartType = "lineChart";
 const chartOption = {
@@ -115,6 +131,10 @@ chartIns.render();
 
 ```javascript
 // 示例
+import HuiCharts from '{{VITE_BASECOPYRIGHTSPAT}}';
+// 引入样式
+import '{{VITE_BASECOPYRIGHTSPAT}}/feature/expandLegend/index.css'
+
 const chartIns = new HuiCharts();
 const chartType = "lineChart";
 const chartOption = {
@@ -150,6 +170,10 @@ chartIns.render();
 
 ```javascript
 // 示例
+import HuiCharts from '{{VITE_BASECOPYRIGHTSPAT}}';
+// 引入样式
+import '{{VITE_BASECOPYRIGHTSPAT}}/feature/expandLegend/index.css'
+
 const chartIns = new HuiCharts();
 const chartType = "lineChart";
 const chartOption = {

--- a/public/quick_start/ExtendListLegend.md
+++ b/public/quick_start/ExtendListLegend.md
@@ -164,6 +164,10 @@ const chartData = {
     smooth: true,
 };
 
+import HuiCharts from '{{VITE_BASECOPYRIGHTSPAT}}';
+// 引入样式
+import '{{VITE_BASECOPYRIGHTSPAT}}/feature/expandLegend/index.css'
+
 export default {
     name: "ListLegend",
     data() {
@@ -173,7 +177,7 @@ export default {
         };
     },
     created() {
-        this.airportIntegrateChart = new IntegrateChart();
+        this.airportIntegrateChart = new HuiCharts();
     },
     mounted() {
         this.renderChart();

--- a/public/quick_start/ExtendMutiSelectLegend.md
+++ b/public/quick_start/ExtendMutiSelectLegend.md
@@ -179,6 +179,10 @@ const ChartData = {
     smooth: true,
 };
 
+import HuiCharts from '{{VITE_BASECOPYRIGHTSPAT}}';
+// 引入样式
+import '{{VITE_BASECOPYRIGHTSPAT}}/feature/expandLegend/index.css'
+
 export default {
     name: "MutiselectLegend",
     data() {
@@ -188,7 +192,7 @@ export default {
         };
     },
     created() {
-        this.integrateChart = new IntegrateChart();
+        this.integrateChart = new HuiCharts();
     },
     mounted() {
         this.renderChart();

--- a/public/quick_start/ExtendSingleSelectLegend.md
+++ b/public/quick_start/ExtendSingleSelectLegend.md
@@ -28,6 +28,10 @@ const ChartData = {
     selectedMode: "multiple",
 };
 
+import HuiCharts from '{{VITE_BASECOPYRIGHTSPAT}}';
+// 引入样式
+import '{{VITE_BASECOPYRIGHTSPAT}}/feature/expandLegend/index.css'
+
 export default {
     name: "SingleselectLegend",
     data() {
@@ -37,7 +41,7 @@ export default {
         };
     },
     created() {
-        this.integrateChart = new IntegrateChart();
+        this.integrateChart = new HuiCharts();
     },
     mounted() {
         this.renderChart();

--- a/public/quick_start/ExtendTableLegend.md
+++ b/public/quick_start/ExtendTableLegend.md
@@ -206,6 +206,11 @@ const chartData2 = {
     type: "pie",
     selectedMode: "multiple",
 };
+
+import HuiCharts from '{{VITE_BASECOPYRIGHTSPAT}}';
+// 引入样式
+import '{{VITE_BASECOPYRIGHTSPAT}}/feature/expandLegend/index.css'
+
 export default {
 	name: 'TableLegend',
 	data() {
@@ -215,8 +220,8 @@ export default {
 		}
 	},
 	created() {
-		this.chartContainer1 = new IntegrateChart();
-		this.chartContainer2 = new IntegrateChart();
+		this.chartContainer1 = new HuiCharts();
+		this.chartContainer2 = new HuiCharts();
 
 	},
 	mounted() {

--- a/src/core.js
+++ b/src/core.js
@@ -169,6 +169,10 @@ export default class CoreChart extends BaseChart {
     if (iChartOption.readScreen) {
       readScreen(this.dom, iChartOption.readScreen);
     }
+    // 使用图例扩展时屏蔽默认图例
+    if (iChartOption?.legend?.upgrade?.type !== undefined){
+      iChartOption.legend.show = false;
+    }
     // 如果是复杂图表，则重定向this指向
     if (this.isSelfChart(ChartClass)) {
       this.redirectSelfChart(ChartClass, iChartOption, plugins);

--- a/src/feature/expandLegend/index.js
+++ b/src/feature/expandLegend/index.js
@@ -42,7 +42,6 @@ function expandLegend(chartsIns) {
             createSingleSelectLegend(chartsIns);
             break;
     }
-    chartsIns.setOption(option);
 }
 
 function createMutiSelect(chartsIns) {


### PR DESCRIPTION
…hics being displayed simultaneously

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Default legend is now automatically hidden when using the enhanced legend, preventing duplicate legends.
  - Reduced redundant re-rendering when applying the expanded legend for smoother interactions.

- Documentation
  - Quick start guides updated to use HuiCharts across legend examples.
  - All example snippets now include explicit imports for HuiCharts and the expandLegend styles.
  - Updated examples for single-select, multi-select, list, and table legends to reflect the new chart engine usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->