### PR TITLE
fix(Token): modify the itemSize of the ict legend

### DIFF
--- a/src/feature/token/theme/ict/getAliasToken.js
+++ b/src/feature/token/theme/ict/getAliasToken.js
@@ -269,7 +269,7 @@ function getAliasToken(globalToken, sceneToken) {
     // 图例单元尺寸
     legendItemSize: size05x,
     // 图例圆形单元尺寸
-    legendCircleItemSize: size3x,
+    legendCircleItemSize: size3x - 2,
     // labelLine的长度
     labelLineLength: size6x,
     // ------------------------------------------------圆角---------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Chart legend indicator dots are now slightly smaller.
  * Visual spacing and alignment in chart legends are adjusted to reflect the new dot size, yielding a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->