### PR TITLE
fix(PieChart): ensure the users can modify barwidth

### DIFF
--- a/src/components/PieChart/handleSeries.js
+++ b/src/components/PieChart/handleSeries.js
@@ -77,8 +77,8 @@ function setCircleRadius(radius, chartInstance, iChartOption, legend) {
   const canvasRadius = width > height ? height / 2 : width / 2;
   const adaptive = iChartOption?.adaptive;
   // 暂时用来只开放华为云主题
-  const theme = iChartOption?.theme
-  let barWidth = chartToken.barWidth;
+  const theme = iChartOption?.theme;
+  let barWidth = iChartOption.barWidth || chartToken.barWidth;
 
   // 2.自适应根据圆环占比部分决定圆环粗细
   if (adaptive && theme.includes('cloud')) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support to override pie/donut ring thickness via a chart option. When provided, the custom bar width is used to compute inner/outer radii, giving finer control over visual thickness.
  * Backwards compatible: existing charts keep the previous appearance if no custom value is set.
  * No API signature changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->