### PR TITLE
fix(BarLineChart): modify the issue of units not being displayed

### DIFF
--- a/src/components/BarLineChart/index.js
+++ b/src/components/BarLineChart/index.js
@@ -107,39 +107,6 @@ class BarLineChart {
       });
     }
     baseOption.series = series;
-    // 处理双Y轴对齐
-    if(baseOption.yAxis && baseOption.yAxis.length === 2) {
-      const result = [];
-      const yAxisLeft = baseOption.yAxis[0];
-      const yAxisRight = baseOption.yAxis[1];
-      const padding = iChartOption.padding;
-      result.push({
-        text:yAxisLeft.name,
-        textStyle: {
-          fontWeight: 'normal',
-          color: Theme.config.yAxisNameColor,
-          fontSize: Theme.config.yAxisNameFontSize,
-        },
-        padding:0,
-        top: padding[0] - 30,
-        left: padding[3]
-      })
-      result.push({
-        text:yAxisRight.name,
-        textStyle: {
-          fontWeight: 'normal',
-          color: Theme.config.yAxisNameColor,
-          fontSize: Theme.config.yAxisNameFontSize,
-        },
-        padding:0,
-        textAlign: 'left',
-        top: padding[0] - 30,
-        right: padding[1]
-      })
-      baseOption.title = result;
-      yAxisLeft.name = '';
-      yAxisRight.name = '';
-    }
     // 如果存在 dataZoom，提前返回
     if (this.baseOption.dataZoom[0].show === true) {
       return;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dual Y-axis charts no longer convert axis names into a combined chart title.
  * Left and right Y-axis names now remain visible on their respective axes, improving clarity and preventing confusing or overlapping titles.
  * Other chart behaviors (data zoom, bar width, adaptive sizing) are unaffected.

* **Chores**
  * No changes to the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->