### PR TITLE
fix(adaptive): add bottom padding when dataZoom exists in adaptive mode

### DIFF
--- a/src/feature/svgLegend/index.js
+++ b/src/feature/svgLegend/index.js
@@ -99,6 +99,7 @@ function createLegend(option, secondaryRender){
   let truncateIndex ;
   for (let index = 0; index < legendData.length; index++) {
     const item = legendData[index];
+    let preItem = legendData[index-1];
     const type = item.icon || iChartOption.legend?.icon || legend.icon || 'rect';
     const style = {
       x: startX,
@@ -114,7 +115,16 @@ function createLegend(option, secondaryRender){
       legendRight: right
     }
     const name = item.name || item;
-    const itemConfig = createItem(g, type, style, svgNS, name, index, legend, legendWidth, secondaryRender)
+    const itemConfig = createItem(g, type, style, svgNS, name, index, legend, legendWidth, secondaryRender);
+    if(itemConfig.preTruncation && preItem){
+      truncateIndex = index - 1;
+      if (secondaryRender) {
+        style.x = startX;
+        createEllipsis(g, type, style, svgNS, name, index+1);
+        createDropDown(container, legend, legendData, index+1, iChartOption, chartInstance);
+      }
+      break;
+    }
     itemWidth = itemConfig.itemWidth;
     startX += itemWidth;
     // style.x = startX;
@@ -279,6 +289,10 @@ function createItem(svg, type, style, svgNS, name, index, legend, legendWidth, s
       legendText.innerHTML = newText
     }
     itemWidth = legendText.getBBox().width + width + 6;
+    if(newTextLength === 0){
+      g.remove();
+      return {itemWidth, preTruncation:true, truncation: false};
+    }
     return {itemWidth, truncation: true};
   }
   return {itemWidth, truncation: false};

--- a/src/option/RectSys/adaptive.js
+++ b/src/option/RectSys/adaptive.js
@@ -13,6 +13,7 @@ import datazoom from '../config/datazoom';
 import xkey from '../config/xAxis/xkey';
 import xdata from '../config/xAxis/xdata';
 import mobile from '../../util/mobile';
+import { isArray } from '../../util/type';
 // 组装直角坐标系自适应
 function AdaptiveRectSys(baseOpt, iChartOpt, echartsIns, self) {
   if (baseOpt.xAxis[0].type !== 'category') return;
@@ -32,6 +33,21 @@ function AdaptiveRectSys(baseOpt, iChartOpt, echartsIns, self) {
   // 设置字体
   ctx.font = `${fontWeight} ${fontSize} ${fontFamily}`;
   let maxItemWidth = (rect.width - (iXdata.length - 1) * 8) / iXdata.length;
+  // 计算超出最合适的datazoom end
+  let overLoneWidth = 0;
+  let overLoneIndex = 0;
+  for (let index = 0; index < iXdata.length; index++) {
+    const item = iXdata[index];
+    const width = ctx.measureText(item).width;
+    if(maxItemWidth < width){
+      overLoneWidth += width + 8;
+      overLoneIndex ++;
+    }
+  }
+  // 为了文字完全显示，计算出超长文字 + 最小间隙对 / 默认单项的宽度
+  const regularWidth = maxItemWidth * overLoneIndex + 8 * overLoneIndex
+  const widthParcent = parseFloat((regularWidth / overLoneWidth) * 100 );
+
   for (let index = 0; index < iXdata.length; index++) {
     const item = iXdata[index];
     const next = iXdata[index+1] ;
@@ -46,17 +62,30 @@ function AdaptiveRectSys(baseOpt, iChartOpt, echartsIns, self) {
           iChartOpt.dataZoom.mini = true;
           iChartOpt.dataZoom.bottom = 0;
           iChartOpt.dataZoom.start = 0;
-          iChartOpt.dataZoom.end = iChartOpt.dataZoom.end || 80;
+          iChartOpt.dataZoom.end = iChartOpt.dataZoom.end || 80; // widthParcent < 30 ? 30 : widthParcent;
           iChartOpt.dataZoom.type = isMobile ? "inside" : 'slider';
+          // 设定底部datazoom 预留高度需大于 18 --- 取自设计稿
+          if(iChartOpt.padding && isArray(iChartOpt.padding) && iChartOpt.padding[2] < 18){
+            setAdaptiveGrid(baseOpt, 18)
+          }
         }
         break;
       } else {
         iChartOpt.dataZoom.show = false;
+        setAdaptiveGrid(baseOpt, iChartOpt.padding?.[2] || 0 )
       }
     }
   }
   // 图表datazoom
   baseOpt.dataZoom = datazoom(iChartOpt);
+}
+
+function setAdaptiveGrid(baseOpt, value){
+  if (isArray(baseOpt.grid)) {
+    baseOpt.grid[0].bottom = value;
+  } else {
+    baseOpt.grid.bottom = value;
+  }
 }
 
 export default AdaptiveRectSys;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic chart grid spacing to better accommodate labels and avoid overlap.
  * Fixed grid bottom padding behavior when zoom is enabled or disabled to ensure consistent layout.
  * Prevented rendering of empty/empty-truncated legend entries that could cause display issues.

* **Enhancements**
  * Added a pre-truncation step for legends to better handle long labels and dropdown placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->