### PR TITLE
fix(adaptive): add bottom padding when dataZoom exists in adaptive mode

### DIFF
--- a/src/option/RectSys/adaptive.js
+++ b/src/option/RectSys/adaptive.js
@@ -13,6 +13,7 @@ import datazoom from '../config/datazoom';
 import xkey from '../config/xAxis/xkey';
 import xdata from '../config/xAxis/xdata';
 import mobile from '../../util/mobile';
+import { isArray } from '../../util/type';
 // 组装直角坐标系自适应
 function AdaptiveRectSys(baseOpt, iChartOpt, echartsIns, self) {
   if (baseOpt.xAxis[0].type !== 'category') return;
@@ -32,6 +33,21 @@ function AdaptiveRectSys(baseOpt, iChartOpt, echartsIns, self) {
   // 设置字体
   ctx.font = `${fontWeight} ${fontSize} ${fontFamily}`;
   let maxItemWidth = (rect.width - (iXdata.length - 1) * 8) / iXdata.length;
+  // 计算超出最合适的datazoom end
+  let overLoneWidth = 0;
+  let overLoneIndex = 0;
+  for (let index = 0; index < iXdata.length; index++) {
+    const item = iXdata[index];
+    const width = ctx.measureText(item).width;
+    if(maxItemWidth < width){
+      overLoneWidth += width + 8;
+      overLoneIndex ++;
+    }
+  }
+  // 为了文字完全显示，计算出超长文字 + 最小间隙对 / 默认单项的宽度
+  const regularWidth = maxItemWidth * overLoneIndex + 8 * overLoneIndex
+  const widthParcent = parseFloat((regularWidth / overLoneWidth) * 100 );
+
   for (let index = 0; index < iXdata.length; index++) {
     const item = iXdata[index];
     const next = iXdata[index+1] ;
@@ -46,17 +62,30 @@ function AdaptiveRectSys(baseOpt, iChartOpt, echartsIns, self) {
           iChartOpt.dataZoom.mini = true;
           iChartOpt.dataZoom.bottom = 0;
           iChartOpt.dataZoom.start = 0;
-          iChartOpt.dataZoom.end = iChartOpt.dataZoom.end || 80;
+          iChartOpt.dataZoom.end = iChartOpt.dataZoom.end || 80; // widthParcent < 30 ? 30 : widthParcent;
           iChartOpt.dataZoom.type = isMobile ? "inside" : 'slider';
+          // 设定底部datazoom 预留高度需大于 18 --- 取自设计稿
+          if(iChartOpt.padding && isArray(iChartOpt.padding) && iChartOpt.padding[2] < 18){
+            setAdaptiveGrid(baseOpt, 18)
+          }
         }
         break;
       } else {
         iChartOpt.dataZoom.show = false;
+        setAdaptiveGrid(baseOpt, iChartOpt.padding?.[2] || 0 )
       }
     }
   }
   // 图表datazoom
   baseOpt.dataZoom = datazoom(iChartOpt);
+}
+
+function setAdaptiveGrid(baseOpt, value){
+  if (isArray(baseOpt.grid)) {
+    baseOpt.grid[0].bottom = value;
+  } else {
+    baseOpt.grid.bottom = value;
+  }
 }
 
 export default AdaptiveRectSys;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced adaptive chart layout to better manage text overflow in complex configurations
  * Improved bottom grid spacing adjustments when enabling or disabling data zoom features
  * Optimized layout calculations based on content padding for better chart presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->