### PR TITLE
fix(ci): remove workflow-level env block exposing secrets

### DIFF
--- a/.github/workflows/deploy-obs.yml
+++ b/.github/workflows/deploy-obs.yml
@@ -11,13 +11,6 @@ on:
         required: false
         type: string
 
-env:
-  # 在 GitHub 项目源码仓库 → 项目的 Settings → Secrets(Actions 里的 Repository secrets) 里提前建好以下变量
-  HUAWEI_CLOUD_AK: ${{ secrets.HUAWEI_CLOUD_AK }}
-  HUAWEI_CLOUD_SK: ${{ secrets.HUAWEI_CLOUD_SK }}
-  HUAWEI_CLOUD_ENDPOINT: ${{ secrets.HUAWEI_CLOUD_ENDPOINT }}
-  HUAWEI_CLOUD_BUCKET: ${{ secrets.HUAWEI_CLOUD_BUCKET }}
-
 permissions:
   contents: read
   pages: write
@@ -83,11 +76,11 @@ jobs:
       - name: Upload to OBS
         run: |
           # 一次性配置 AK/SK/endpoint
-          obsutil config -i=${{ env.HUAWEI_CLOUD_AK }} \
-                         -k=${{ env.HUAWEI_CLOUD_SK }} \
-                         -e=${{ env.HUAWEI_CLOUD_ENDPOINT }}
+          obsutil config -i=${{ secrets.HUAWEI_CLOUD_AK }} \
+                         -k=${{ secrets.HUAWEI_CLOUD_SK }} \
+                         -e=${{ secrets.HUAWEI_CLOUD_ENDPOINT }}
 
           # 把本地 dist/ 目录整站同步到桶根目录
           echo "needs.build.outputs.version: ${{ needs.build.outputs.version }}"
           mv dist ${{ needs.build.outputs.version }}
-          obsutil cp ${{ needs.build.outputs.version }} obs://${{ env.HUAWEI_CLOUD_BUCKET }}/tiny-charts-web-doc/ -r -f
+          obsutil cp ${{ needs.build.outputs.version }} obs://${{ secrets.HUAWEI_CLOUD_BUCKET }}/tiny-charts-web-doc/ -r -f

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig(({mode})=>{
       port: 8080,
     },
     define: {
-      'process.env': { ...process.env }
+      'process.env': { NODE_ENV: process.env.NODE_ENV }
     },
     resolve: {
       alias: {},


### PR DESCRIPTION
## Summary
- 参照 opentiny/opentiny.design#111，排查并修复 GitHub Actions workflow 中 `HUAWEI_CLOUD_*` 环境变量安全问题
- 移除 `deploy-obs.yml` 中顶层 `env:` 块对 secrets 的映射，改为直接使用 `${{ secrets.HUAWEI_CLOUD_* }}`

## Why
将 secrets 映射到 workflow 级别的 `env:` 会使敏感凭据暴露在环境上下文中（可通过 debug logs 等方式泄露）。直接引用 `${{ secrets.* }}` 更安全，GitHub Actions 会自动在日志中遮盖 secrets 值。

## Test plan
- [ ] 确认 workflow 文件中不再有 `env.HUAWEI_CLOUD_*` 引用
- [ ] 手动触发 workflow 验证 secrets 引用正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to reference repository secrets directly for cloud credentials instead of using top-level environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->